### PR TITLE
feat: add release automation with DMG packaging

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+# Release notes categorization for auto-generated notes
+# Used by GitHub when --generate-notes is passed to gh release create
+changelog:
+  categories:
+    - title: "✨ Features"
+      labels: ["enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["bug"]
+    - title: "🔧 Maintenance"
+      labels: ["chore", "ci", "dependencies"]
+    - title: "📖 Documentation"
+      labels: ["documentation"]
+    - title: "Other Changes"
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install tools
+        run: brew install xcodegen create-dmg
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build Release
+        run: |
+          xcodebuild build \
+            -scheme Transy \
+            -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath ./DerivedData \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify --renderer github-actions
+
+      - name: Verify .app exists
+        run: |
+          APP_PATH="./DerivedData/Build/Products/Release/Transy.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "::error::Transy.app not found at $APP_PATH"
+            exit 1
+          fi
+          echo "✅ Transy.app found"
+          VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+          echo "📦 App version: $VERSION"
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg-source
+          cp -R ./DerivedData/Build/Products/Release/Transy.app ./dmg-source/
+
+          set +e
+          create-dmg \
+            --volname "Transy" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "Transy.app" 150 190 \
+            --hide-extension "Transy.app" \
+            --app-drop-link 450 190 \
+            --no-internet-enable \
+            "Transy-${{ steps.version.outputs.version }}.dmg" \
+            ./dmg-source/
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 2 ]; then
+            echo "::error::create-dmg failed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+
+          ls -la "Transy-${{ steps.version.outputs.version }}.dmg"
+          echo "✅ DMG created successfully"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${{ github.ref_name }}" \
+            "Transy-${{ steps.version.outputs.version }}.dmg#Transy ${{ steps.version.outputs.version }} (macOS)" \
+            --title "Transy ${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            --verify-tag \
+            $PRERELEASE_FLAG

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -31,6 +31,8 @@ Selected text turns into a natural translation almost instantly without breaking
 - ✓ First-launch onboarding with Accessibility permission guidance — v0.3.0
 - ✓ macOS-standard tabbed Settings UI (General / About) — v0.3.0
 - ✓ Launch at Login toggle — v0.3.0
+- ✓ CI pipeline with SwiftLint, SwiftFormat, build and test — Phase 10
+- ✓ Automated release workflow with DMG packaging — Phase 11
 
 ### Active
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -16,9 +16,9 @@ Requirements for DevOps & Improvements milestone. Each maps to roadmap phases.
 
 ### Release Automation
 
-- [ ] **REL-01**: Creating a GitHub Release triggers automated build and DMG creation workflow
-- [ ] **REL-02**: Release workflow creates DMG with drag-to-Applications layout
-- [ ] **REL-03**: Release workflow uploads DMG as a Release asset
+- [x] **REL-01**: Creating a GitHub Release triggers automated build and DMG creation workflow
+- [x] **REL-02**: Release workflow creates DMG with drag-to-Applications layout
+- [x] **REL-03**: Release workflow uploads DMG as a Release asset
 
 ### Clipboard Monitoring
 
@@ -52,9 +52,9 @@ None deferred for this milestone.
 | CI-02 | Phase 10 | Complete |
 | CI-03 | Phase 10 | Complete |
 | CI-04 | Phase 10 | Complete |
-| REL-01 | Phase 11 | Pending |
-| REL-02 | Phase 11 | Pending |
-| REL-03 | Phase 11 | Pending |
+| REL-01 | Phase 11 | Complete |
+| REL-02 | Phase 11 | Complete |
+| REL-03 | Phase 11 | Complete |
 | CLB-01 | Phase 12 | Pending |
 | CLB-02 | Phase 12 | Pending |
 | CLB-03 | Phase 12 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -16,7 +16,7 @@ Requirements for DevOps & Improvements milestone. Each maps to roadmap phases.
 
 ### Release Automation
 
-- [x] **REL-01**: Creating a GitHub Release triggers automated build and DMG creation workflow
+- [x] **REL-01**: Pushing a version tag to GitHub triggers automated build and DMG creation workflow, which then creates a GitHub Release
 - [x] **REL-02**: Release workflow creates DMG with drag-to-Applications layout
 - [x] **REL-03**: Release workflow uploads DMG as a Release asset
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -47,7 +47,7 @@ Full details: [milestones/v0.3.0-ROADMAP.md](milestones/v0.3.0-ROADMAP.md)
 **Milestone Goal:** Establish CI/CD pipeline, automate releases with DMG packaging, add permission-free clipboard monitoring trigger, and simplify translation model downloads.
 
 - [x] **Phase 10: CI Pipeline** - GitHub Actions workflow with SwiftLint, SwiftFormat, build, and test on PRs (completed 2026-03-27)
-- [ ] **Phase 11: Release Automation** - Release-triggered workflow that builds, packages DMG, and uploads to GitHub Release
+- [ ] **Phase 11: Release Automation** - Release-triggered workflow that builds, packages DMG, and uploads to GitHub Release (1 plan)
 - [ ] **Phase 12: Clipboard Monitoring** - Permission-free trigger mode via NSPasteboard polling with Settings UI
 - [ ] **Phase 13: Translation Download UI** - Framework-native model download prompt replaces manual System Settings guidance
 
@@ -76,7 +76,10 @@ Plans:
   1. Creating a GitHub Release from the UI triggers an automated workflow that builds the app in Release configuration
   2. The workflow produces a DMG containing Transy.app with a drag-to-Applications layout
   3. The DMG is uploaded as an asset on the GitHub Release with auto-generated release notes
-**Plans**: TBD
+**Plans**: 1 plan
+
+Plans:
+- [ ] 11-01-PLAN.md — Release workflow and release notes config (tag trigger → Release build → DMG → GitHub Release)
 
 ### Phase 12: Clipboard Monitoring
 **Goal**: Users can translate copied text without Accessibility permission by enabling clipboard monitoring as an alternative trigger mode

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -47,7 +47,7 @@ Full details: [milestones/v0.3.0-ROADMAP.md](milestones/v0.3.0-ROADMAP.md)
 **Milestone Goal:** Establish CI/CD pipeline, automate releases with DMG packaging, add permission-free clipboard monitoring trigger, and simplify translation model downloads.
 
 - [x] **Phase 10: CI Pipeline** - GitHub Actions workflow with SwiftLint, SwiftFormat, build, and test on PRs (completed 2026-03-27)
-- [x] **Phase 11: Release Automation** - Release-triggered workflow that builds, packages DMG, and uploads to GitHub Release (1 plan) (completed 2026-03-29)
+- [x] **Phase 11: Release Automation** - Tag-push-triggered workflow that builds, packages a DMG, and creates/uploads a GitHub Release (1 plan) (completed 2026-03-29)
 - [ ] **Phase 12: Clipboard Monitoring** - Permission-free trigger mode via NSPasteboard polling with Settings UI
 - [ ] **Phase 13: Translation Download UI** - Framework-native model download prompt replaces manual System Settings guidance
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -47,7 +47,7 @@ Full details: [milestones/v0.3.0-ROADMAP.md](milestones/v0.3.0-ROADMAP.md)
 **Milestone Goal:** Establish CI/CD pipeline, automate releases with DMG packaging, add permission-free clipboard monitoring trigger, and simplify translation model downloads.
 
 - [x] **Phase 10: CI Pipeline** - GitHub Actions workflow with SwiftLint, SwiftFormat, build, and test on PRs (completed 2026-03-27)
-- [ ] **Phase 11: Release Automation** - Release-triggered workflow that builds, packages DMG, and uploads to GitHub Release (1 plan)
+- [x] **Phase 11: Release Automation** - Release-triggered workflow that builds, packages DMG, and uploads to GitHub Release (1 plan) (completed 2026-03-29)
 - [ ] **Phase 12: Clipboard Monitoring** - Permission-free trigger mode via NSPasteboard polling with Settings UI
 - [ ] **Phase 13: Translation Download UI** - Framework-native model download prompt replaces manual System Settings guidance
 
@@ -79,7 +79,7 @@ Plans:
 **Plans**: 1 plan
 
 Plans:
-- [ ] 11-01-PLAN.md — Release workflow and release notes config (tag trigger → Release build → DMG → GitHub Release)
+- [x] 11-01-PLAN.md — Release workflow and release notes config (tag trigger → Release build → DMG → GitHub Release)
 
 ### Phase 12: Clipboard Monitoring
 **Goal**: Users can translate copied text without Accessibility permission by enabling clipboard monitoring as an alternative trigger mode
@@ -117,7 +117,7 @@ Plans:
 | 8. First-Launch Onboarding | v0.3.0 | 1/1 | Complete | 2026-03-23 |
 | 9. General Settings Features | v0.3.0 | 1/1 | Complete | 2026-03-25 |
 | 10. CI Pipeline | v0.4.0 | 2/2 | Complete    | 2026-03-27 |
-| 11. Release Automation | v0.4.0 | 0/? | Not started | - |
+| 11. Release Automation | v0.4.0 | 1/1 | Complete   | 2026-03-29 |
 | 12. Clipboard Monitoring | v0.4.0 | 0/? | Not started | - |
 | 13. Translation Download UI | v0.4.0 | 0/? | Not started | - |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -117,7 +117,7 @@ Plans:
 | 8. First-Launch Onboarding | v0.3.0 | 1/1 | Complete | 2026-03-23 |
 | 9. General Settings Features | v0.3.0 | 1/1 | Complete | 2026-03-25 |
 | 10. CI Pipeline | v0.4.0 | 2/2 | Complete    | 2026-03-27 |
-| 11. Release Automation | v0.4.0 | 1/1 | Complete   | 2026-03-29 |
+| 11. Release Automation | v0.4.0 | 1/1 | Complete    | 2026-03-29 |
 | 12. Clipboard Monitoring | v0.4.0 | 0/? | Not started | - |
 | 13. Translation Download UI | v0.4.0 | 0/? | Not started | - |
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.0
 milestone_name: DevOps & Improvements
-status: Phase complete — ready for verification
+status: Ready to plan
 stopped_at: Completed 11-01-PLAN.md
-last_updated: "2026-03-29T13:33:03.924Z"
+last_updated: "2026-03-29T13:37:13.293Z"
 progress:
   total_phases: 4
   completed_phases: 2
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-03-25)
 
 ## Current Position
 
-Phase: 11 (release-automation) — EXECUTING
-Plan: 1 of 1
+Phase: 12
+Plan: Not started
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.4.0
 milestone_name: DevOps & Improvements
 status: Ready to plan
-stopped_at: Completed 10-01-PLAN.md
-last_updated: "2026-03-27T23:04:06.087Z"
+stopped_at: Phase 11 context gathered
+last_updated: "2026-03-29T13:10:51.338Z"
 progress:
   total_phases: 4
   completed_phases: 1
@@ -84,6 +84,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-03-27T22:48:05.684Z
-Stopped at: Completed 10-01-PLAN.md
-Resume file: None
+Last session: 2026-03-29T13:10:51.335Z
+Stopped at: Phase 11 context gathered
+Resume file: .planning/phases/11-release-automation/11-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,12 +3,12 @@ gsd_state_version: 1.0
 milestone: v0.4.0
 milestone_name: DevOps & Improvements
 status: Ready to plan
-stopped_at: Phase 11 context gathered
-last_updated: "2026-03-29T13:10:51.338Z"
+stopped_at: Phase 11 planned
+last_updated: "2026-03-29T13:24:15.899Z"
 progress:
   total_phases: 4
   completed_phases: 1
-  total_plans: 2
+  total_plans: 3
   completed_plans: 2
 ---
 
@@ -84,6 +84,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-03-29T13:10:51.335Z
-Stopped at: Phase 11 context gathered
-Resume file: .planning/phases/11-release-automation/11-CONTEXT.md
+Last session: 2026-03-29T13:24:15.891Z
+Stopped at: Phase 11 planned
+Resume file: .planning/phases/11-release-automation/11-01-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.4.0
 milestone_name: DevOps & Improvements
-status: Ready to plan
-stopped_at: Phase 11 planned
-last_updated: "2026-03-29T13:24:15.899Z"
+status: Phase complete — ready for verification
+stopped_at: Completed 11-01-PLAN.md
+last_updated: "2026-03-29T13:33:03.924Z"
 progress:
   total_phases: 4
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 3
-  completed_plans: 2
+  completed_plans: 3
 ---
 
 # Project State
@@ -19,12 +19,12 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-25)
 
 **Core value:** Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
-**Current focus:** Phase 10 — ci-pipeline
+**Current focus:** Phase 11 — release-automation
 
 ## Current Position
 
-Phase: 11
-Plan: Not started
+Phase: 11 (release-automation) — EXECUTING
+Plan: 1 of 1
 
 ## Performance Metrics
 
@@ -48,6 +48,7 @@ Plan: Not started
 | 08    | 01   | 72s (1.2m)  | 2     | 2     | 2026-03-23T13:21:00Z |
 | Phase 10-ci-pipeline P02 | 65 | 1 tasks | 1 files |
 | Phase 10 P01 | 88 | 2 tasks | 5 files |
+| Phase 11 P01 | 98 | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -72,6 +73,9 @@ Recent decisions affecting current work:
 - [Phase 10-ci-pipeline]: fetch-depth: 0 only on build-and-test job for git describe --tags version script
 - [Phase 10]: D-01: Strict SwiftLint with 150-char line limit and 17 opt-in rules
 - [Phase 10]: D-05: SwiftFormat disables redundantSelf/trailingCommas to avoid SwiftLint conflicts
+- [Phase 11]: D-01: Tag push trigger (on: push: tags: [v*]) for release workflow
+- [Phase 11]: D-03: create-dmg via Homebrew for drag-to-Applications DMG layout with exit code 2 tolerance
+- [Phase 11]: D-05: Auto-generated release notes via gh release create --generate-notes with PR categorization
 
 ### Pending Todos
 
@@ -84,6 +88,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-03-29T13:24:15.891Z
-Stopped at: Phase 11 planned
-Resume file: .planning/phases/11-release-automation/11-01-PLAN.md
+Last session: 2026-03-29T13:33:03.922Z
+Stopped at: Completed 11-01-PLAN.md
+Resume file: None

--- a/.planning/phases/11-release-automation/11-01-PLAN.md
+++ b/.planning/phases/11-release-automation/11-01-PLAN.md
@@ -1,0 +1,429 @@
+---
+phase: 11-release-automation
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .github/release.yml
+  - .github/workflows/release.yml
+autonomous: true
+requirements: [REL-01, REL-02, REL-03]
+
+must_haves:
+  truths:
+    - "Pushing a v* tag triggers the release workflow"
+    - "Workflow builds the app in Release configuration"
+    - "Workflow creates a DMG with Transy.app and an Applications drop link"
+    - "Workflow creates a GitHub Release with auto-generated categorized notes and the DMG attached"
+    - "Tags with hyphens produce pre-releases"
+  artifacts:
+    - path: ".github/workflows/release.yml"
+      provides: "Complete release automation workflow"
+      contains: "on:\n  push:\n    tags:"
+    - path: ".github/release.yml"
+      provides: "Release notes PR categorization"
+      contains: "changelog:"
+  key_links:
+    - from: ".github/workflows/release.yml"
+      to: "create-dmg"
+      via: "brew install + create-dmg CLI invocation"
+      pattern: "create-dmg"
+    - from: ".github/workflows/release.yml"
+      to: "GitHub Releases API"
+      via: "gh release create with --generate-notes"
+      pattern: "gh release create"
+    - from: ".github/release.yml"
+      to: ".github/workflows/release.yml"
+      via: "GitHub uses release.yml to categorize --generate-notes output"
+      pattern: "changelog:"
+---
+
+<objective>
+Create the GitHub Actions release workflow and release notes configuration for automated DMG builds.
+
+Purpose: When a version tag (e.g., `v0.4.0`) is pushed, the workflow builds Transy in Release configuration, packages it into a DMG with a drag-to-Applications layout using `create-dmg`, and publishes a GitHub Release with the DMG asset and auto-generated categorized release notes.
+
+Output: `.github/workflows/release.yml` (release workflow), `.github/release.yml` (release notes config)
+</objective>
+
+<execution_context>
+@.github/get-shit-done/workflows/execute-plan.md
+@.github/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/11-release-automation/11-CONTEXT.md
+@.planning/research/release-automation.md
+
+<interfaces>
+<!-- Existing CI workflow patterns to replicate in release workflow -->
+
+From .github/workflows/ci.yml:
+```yaml
+# Homebrew env vars (reuse in release workflow)
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+# Code signing overrides (reuse in release build)
+CODE_SIGN_IDENTITY="-"
+CODE_SIGNING_REQUIRED=NO
+CODE_SIGNING_ALLOWED=NO
+
+# xcbeautify for readable output
+| xcbeautify --renderer github-actions
+
+# XcodeGen install pattern
+brew install xcodegen
+xcodegen generate
+
+# Full history checkout for git describe
+fetch-depth: 0
+```
+
+From project.yml (post-build script — auto-sets version from git tag):
+```yaml
+postBuildScripts:
+  - script: |
+      VERSION=$(git -C "$SRCROOT" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+      if [ -n "$VERSION" ]; then
+        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
+      fi
+    name: Set Version from Git Tag
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create release notes categorization config</name>
+  <files>.github/release.yml</files>
+  <read_first>
+    - .planning/phases/11-release-automation/11-CONTEXT.md (D-06 decision)
+    - .planning/research/release-automation.md (Section 3: release.yml template)
+  </read_first>
+  <action>
+Create `.github/release.yml` with PR categorization for auto-generated release notes (per D-06).
+
+File content:
+
+```yaml
+# Release notes categorization for auto-generated notes
+# Used by GitHub when --generate-notes is passed to gh release create
+changelog:
+  categories:
+    - title: "✨ Features"
+      labels: ["enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["bug"]
+    - title: "🔧 Maintenance"
+      labels: ["chore", "ci", "dependencies"]
+    - title: "📖 Documentation"
+      labels: ["documentation"]
+    - title: "Other Changes"
+      labels: ["*"]
+```
+
+This file tells GitHub how to group PRs when generating release notes. The `*` catch-all ensures no PR is omitted.
+  </action>
+  <verify>
+    <automated>test -f .github/release.yml && grep -q "changelog:" .github/release.yml && grep -q 'labels: \["enhancement"\]' .github/release.yml && echo "PASS" || echo "FAIL"</automated>
+  </verify>
+  <acceptance_criteria>
+    - .github/release.yml exists
+    - File contains `changelog:` top-level key
+    - File contains category `"✨ Features"` with labels `["enhancement"]`
+    - File contains category `"🐛 Bug Fixes"` with labels `["bug"]`
+    - File contains category `"🔧 Maintenance"` with labels `["chore", "ci", "dependencies"]`
+    - File contains category `"📖 Documentation"` with labels `["documentation"]`
+    - File contains catch-all category `"Other Changes"` with labels `["*"]`
+  </acceptance_criteria>
+  <done>`.github/release.yml` exists with 5 PR categories (Features, Bug Fixes, Maintenance, Documentation, Other Changes) matching the research template exactly.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create release workflow</name>
+  <files>.github/workflows/release.yml</files>
+  <read_first>
+    - .github/workflows/ci.yml (existing CI patterns to mirror: Homebrew env vars, code signing overrides, xcbeautify, XcodeGen install)
+    - .planning/phases/11-release-automation/11-CONTEXT.md (D-01 through D-05, D-07 decisions)
+    - .planning/research/release-automation.md (Section 4: complete workflow YAML, Section 6: create-dmg exit code 2 handling)
+    - project.yml (post-build script confirms version injection from git tags works automatically)
+  </read_first>
+  <action>
+Create `.github/workflows/release.yml` implementing the full release pipeline. The workflow has these steps:
+
+**Trigger (per D-01, D-02):** `on: push: tags: ['v*']` — tag push triggers; the workflow creates the release.
+
+**Permissions:** `permissions: contents: write` — required for `GITHUB_TOKEN` to create releases.
+
+**Global env vars (matching ci.yml pattern):**
+```yaml
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+```
+
+**Single job `release` on `macos-15` with these steps:**
+
+1. **Checkout** — `actions/checkout@v4` with `fetch-depth: 0` (full history for `git describe --tags` version script in project.yml post-build).
+
+2. **Extract version from tag** — Step id `version`. Strips `v` prefix:
+```bash
+echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+```
+
+3. **Install tools** — Single brew install for both tools:
+```bash
+brew install xcodegen create-dmg
+```
+
+4. **Generate Xcode project** — `xcodegen generate`
+
+5. **Build Release** — xcodebuild with `-configuration Release` and `-derivedDataPath ./DerivedData`. Same code signing overrides as ci.yml. Pipe through xcbeautify:
+```bash
+xcodebuild build \
+  -scheme Transy \
+  -configuration Release \
+  -destination 'platform=macOS' \
+  -derivedDataPath ./DerivedData \
+  CODE_SIGN_IDENTITY="-" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  | xcbeautify --renderer github-actions
+```
+
+6. **Verify .app exists** — Check `./DerivedData/Build/Products/Release/Transy.app` exists as a directory. Print the embedded version from Info.plist using PlistBuddy:
+```bash
+APP_PATH="./DerivedData/Build/Products/Release/Transy.app"
+if [ ! -d "$APP_PATH" ]; then
+  echo "::error::Transy.app not found at $APP_PATH"
+  exit 1
+fi
+echo "✅ Transy.app found"
+VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+echo "📦 App version: $VERSION"
+```
+
+7. **Create DMG (per D-03, D-04)** — Stage the .app, run `create-dmg` with exit code 2 handling. Uses `set +e` / `set -e` pattern to catch only real failures:
+```bash
+mkdir -p dmg-source
+cp -R ./DerivedData/Build/Products/Release/Transy.app ./dmg-source/
+
+set +e
+create-dmg \
+  --volname "Transy" \
+  --window-pos 200 120 \
+  --window-size 600 400 \
+  --icon-size 100 \
+  --icon "Transy.app" 150 190 \
+  --hide-extension "Transy.app" \
+  --app-drop-link 450 190 \
+  --no-internet-enable \
+  "Transy-${{ steps.version.outputs.version }}.dmg" \
+  ./dmg-source/
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 2 ]; then
+  echo "::error::create-dmg failed with exit code $EXIT_CODE"
+  exit $EXIT_CODE
+fi
+
+ls -la "Transy-${{ steps.version.outputs.version }}.dmg"
+echo "✅ DMG created successfully"
+```
+
+8. **Create GitHub Release (per D-05, D-07)** — Uses `gh release create` with `--generate-notes` and `--verify-tag`. Pre-release detection checks for hyphen in tag name:
+```bash
+PRERELEASE_FLAG=""
+if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
+
+gh release create "${{ github.ref_name }}" \
+  "Transy-${{ steps.version.outputs.version }}.dmg#Transy ${{ steps.version.outputs.version }} (macOS)" \
+  --title "Transy ${{ steps.version.outputs.version }}" \
+  --generate-notes \
+  --verify-tag \
+  $PRERELEASE_FLAG
+```
+  Set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` as env var on this step.
+
+**Complete workflow file:**
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install tools
+        run: brew install xcodegen create-dmg
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build Release
+        run: |
+          xcodebuild build \
+            -scheme Transy \
+            -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath ./DerivedData \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify --renderer github-actions
+
+      - name: Verify .app exists
+        run: |
+          APP_PATH="./DerivedData/Build/Products/Release/Transy.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "::error::Transy.app not found at $APP_PATH"
+            exit 1
+          fi
+          echo "✅ Transy.app found"
+          VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+          echo "📦 App version: $VERSION"
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg-source
+          cp -R ./DerivedData/Build/Products/Release/Transy.app ./dmg-source/
+
+          set +e
+          create-dmg \
+            --volname "Transy" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "Transy.app" 150 190 \
+            --hide-extension "Transy.app" \
+            --app-drop-link 450 190 \
+            --no-internet-enable \
+            "Transy-${{ steps.version.outputs.version }}.dmg" \
+            ./dmg-source/
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 2 ]; then
+            echo "::error::create-dmg failed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+
+          ls -la "Transy-${{ steps.version.outputs.version }}.dmg"
+          echo "✅ DMG created successfully"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${{ github.ref_name }}" \
+            "Transy-${{ steps.version.outputs.version }}.dmg#Transy ${{ steps.version.outputs.version }} (macOS)" \
+            --title "Transy ${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            --verify-tag \
+            $PRERELEASE_FLAG
+```
+  </action>
+  <verify>
+    <automated>test -f .github/workflows/release.yml && grep -q "on:" .github/workflows/release.yml && grep -q "tags:" .github/workflows/release.yml && grep -q "create-dmg" .github/workflows/release.yml && grep -q "gh release create" .github/workflows/release.yml && grep -q "permissions:" .github/workflows/release.yml && grep -q "\-\-generate-notes" .github/workflows/release.yml && grep -q "\-\-verify-tag" .github/workflows/release.yml && grep -q "prerelease" .github/workflows/release.yml && echo "PASS" || echo "FAIL"</automated>
+  </verify>
+  <acceptance_criteria>
+    - .github/workflows/release.yml exists
+    - Trigger is `on: push: tags: ['v*']` (per D-01)
+    - No `on: release` event present (per D-02)
+    - `permissions: contents: write` is set at workflow level
+    - Global env contains `HOMEBREW_NO_AUTO_UPDATE: 1` and `HOMEBREW_NO_INSTALL_CLEANUP: 1`
+    - Job runs on `macos-15`
+    - Checkout step has `fetch-depth: 0`
+    - Version extraction step has id `version` and uses `${GITHUB_REF_NAME#v}`
+    - `brew install xcodegen create-dmg` installs both tools
+    - `xcodegen generate` step exists
+    - xcodebuild uses `-configuration Release` and `-derivedDataPath ./DerivedData`
+    - xcodebuild has `CODE_SIGN_IDENTITY="-"`, `CODE_SIGNING_REQUIRED=NO`, `CODE_SIGNING_ALLOWED=NO`
+    - xcodebuild pipes to `xcbeautify --renderer github-actions`
+    - Verify step checks `./DerivedData/Build/Products/Release/Transy.app` directory exists
+    - DMG step uses `create-dmg` with `--volname "Transy"`, `--app-drop-link 450 190`, `--no-internet-enable` (per D-03)
+    - DMG step has `set +e` / `set -e` with exit code 2 tolerance (per D-04)
+    - DMG filename follows `Transy-${{ steps.version.outputs.version }}.dmg` pattern
+    - Release step uses `gh release create` with `--generate-notes` (per D-05) and `--verify-tag`
+    - Release step sets `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` env var
+    - Pre-release detection checks for `*"-"*` in tag name and adds `--prerelease` flag (per D-07)
+    - DMG is uploaded with display label `#Transy ${{ steps.version.outputs.version }} (macOS)`
+  </acceptance_criteria>
+  <done>Complete release workflow at `.github/workflows/release.yml` that triggers on v* tag push, builds Release config, creates DMG with drag-to-Applications layout and exit-code-2 tolerance, and publishes a GitHub Release with auto-generated notes, DMG asset, and pre-release support for hyphenated tags.</done>
+</task>
+
+</tasks>
+
+<verification>
+After both tasks complete, verify the full phase:
+
+1. **File existence:**
+   - `test -f .github/release.yml` — release notes config exists
+   - `test -f .github/workflows/release.yml` — release workflow exists
+
+2. **REL-01 (automated build):**
+   - `grep -q "tags:" .github/workflows/release.yml` — triggers on tag push
+   - `grep -q "configuration Release" .github/workflows/release.yml` — builds in Release config
+
+3. **REL-02 (DMG with layout):**
+   - `grep -q "create-dmg" .github/workflows/release.yml` — uses create-dmg
+   - `grep -q "app-drop-link" .github/workflows/release.yml` — has Applications drop link
+
+4. **REL-03 (upload as asset):**
+   - `grep -q "gh release create" .github/workflows/release.yml` — creates GitHub Release
+   - `grep -q "generate-notes" .github/workflows/release.yml` — auto-generated notes
+
+5. **YAML validity:**
+   - `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))" && echo "VALID" || echo "INVALID"`
+   - `python3 -c "import yaml; yaml.safe_load(open('.github/release.yml'))" && echo "VALID" || echo "INVALID"`
+</verification>
+
+<success_criteria>
+- `.github/workflows/release.yml` exists with tag-push trigger, Release build, DMG creation with create-dmg, and GitHub Release creation with DMG asset
+- `.github/release.yml` exists with 5 PR categories for auto-generated release notes
+- All 7 locked decisions (D-01 through D-07) implemented
+- No code signing or notarization (deferred per CONTEXT.md)
+- No CHANGELOG.md (deferred per CONTEXT.md)
+- Workflow patterns (Homebrew env vars, code signing overrides, xcbeautify, XcodeGen) mirror ci.yml
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/11-release-automation/11-01-SUMMARY.md`
+</output>

--- a/.planning/phases/11-release-automation/11-01-SUMMARY.md
+++ b/.planning/phases/11-release-automation/11-01-SUMMARY.md
@@ -1,0 +1,104 @@
+---
+phase: 11-release-automation
+plan: 01
+subsystem: infra
+tags: [github-actions, create-dmg, release, dmg, ci-cd]
+
+requires:
+  - phase: 10-ci-pipeline
+    provides: CI workflow patterns (Homebrew env vars, code signing overrides, xcbeautify, XcodeGen)
+provides:
+  - GitHub Actions release workflow triggered by v* tag push
+  - DMG packaging with drag-to-Applications layout via create-dmg
+  - GitHub Release creation with auto-generated categorized notes
+  - Pre-release support for hyphenated tags
+  - Release notes PR categorization config
+affects: []
+
+tech-stack:
+  added: [create-dmg, gh-release-create]
+  patterns: [tag-triggered-release, exit-code-tolerance, pre-release-detection]
+
+key-files:
+  created:
+    - .github/workflows/release.yml
+    - .github/release.yml
+  modified: []
+
+key-decisions:
+  - "D-01: Tag push trigger (on: push: tags: [v*]) — workflow creates the release, not the other way around"
+  - "D-03: create-dmg via Homebrew for drag-to-Applications DMG layout"
+  - "D-04: Exit code 2 tolerance for create-dmg CI cosmetic failures"
+  - "D-05: Auto-generated release notes via gh release create --generate-notes"
+  - "D-07: Hyphenated tags produce pre-releases via --prerelease flag"
+
+patterns-established:
+  - "Tag-triggered release: v* tag push triggers full build-package-release pipeline"
+  - "Exit code tolerance: set +e / set -e pattern with explicit exit code checking"
+  - "Pre-release detection: shell pattern *-* on tag name for --prerelease flag"
+
+requirements-completed: [REL-01, REL-02, REL-03]
+
+duration: 2min
+completed: 2026-03-29
+---
+
+# Phase 11 Plan 01: Release Automation Summary
+
+**GitHub Actions release workflow: v* tag → Release build → create-dmg packaging → GitHub Release with DMG asset and categorized auto-generated notes**
+
+## Performance
+
+- **Duration:** 98s (~2 min)
+- **Started:** 2026-03-29T13:30:21Z
+- **Completed:** 2026-03-29T13:31:59Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Release notes categorization config with 5 PR categories (Features, Bug Fixes, Maintenance, Documentation, Other)
+- Complete release workflow: tag push → xcodebuild Release build → create-dmg with drag-to-Applications layout → GitHub Release with DMG asset
+- Pre-release support for hyphenated tags (e.g., v1.0.0-beta.1)
+- Exit code 2 tolerance for create-dmg CI cosmetic failures
+- Mirrors CI workflow patterns: Homebrew env vars, code signing overrides, xcbeautify, XcodeGen install
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create release notes categorization config** - `26d09a2` (feat)
+2. **Task 2: Create release workflow** - `f948033` (feat)
+
+## Files Created/Modified
+- `.github/release.yml` - Release notes PR categorization with 5 categories for auto-generated notes
+- `.github/workflows/release.yml` - Complete release pipeline: tag trigger → build → DMG → GitHub Release
+
+## Decisions Made
+None - followed plan as specified. All 7 locked decisions (D-01 through D-07) implemented exactly as documented in CONTEXT.md.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required. The workflow uses `GITHUB_TOKEN` which is automatically available in GitHub Actions.
+
+## Next Phase Readiness
+- Release automation complete and ready for first tag push
+- To trigger: `git tag v0.4.0 && git push origin v0.4.0`
+- Code signing and notarization deferred per CONTEXT.md — users will need to right-click → Open on first launch
+
+## Self-Check: PASSED
+
+- ✅ `.github/release.yml` exists
+- ✅ `.github/workflows/release.yml` exists
+- ✅ `11-01-SUMMARY.md` exists
+- ✅ Commit `26d09a2` found
+- ✅ Commit `f948033` found
+
+---
+*Phase: 11-release-automation*
+*Completed: 2026-03-29*

--- a/.planning/phases/11-release-automation/11-CONTEXT.md
+++ b/.planning/phases/11-release-automation/11-CONTEXT.md
@@ -1,0 +1,103 @@
+# Phase 11: Release Automation - Context
+
+**Gathered:** 2025-07-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+This phase delivers a GitHub Actions workflow that builds a release DMG and publishes a GitHub Release when a version tag is pushed. It covers the full pipeline: tag trigger → Release build → DMG packaging → GitHub Release creation with auto-generated notes and DMG asset.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Trigger Strategy
+- **D-01:** Tag push trigger (`on: push: tags: [v*]`). Pushing a tag like `v0.4.0` fires the workflow. Works from CLI (`git tag && git push`) or GitHub UI.
+- **D-02:** The workflow creates the GitHub Release (not the other way around). No `on: release` event needed.
+
+### DMG Creation
+- **D-03:** Use `create-dmg` (installed via Homebrew). Produces a drag-to-Applications layout with icon positioning.
+- **D-04:** Handle `create-dmg` exit code 2 as success (DMG created but Finder layout couldn't be set — common on CI). Only fail on exit codes other than 0 and 2.
+
+### Release Notes
+- **D-05:** Auto-generated release notes using `gh release create --generate-notes`.
+- **D-06:** Add `.github/release.yml` to categorize PRs into Features, Bug Fixes, Maintenance, Documentation sections.
+
+### Pre-release Support
+- **D-07:** Tags containing a hyphen (e.g., `v0.4.0-beta.1`, `v0.5.0-rc.1`) automatically get the `--prerelease` flag on the GitHub Release. Detected via shell pattern match on the tag name.
+
+### Agent's Discretion
+- Build configuration details (Release vs Archive approach — research recommends `xcodebuild build -configuration Release` for unsigned)
+- DMG window dimensions and icon positions (research provides sensible defaults)
+- Whether to add an `upload-artifact` step for build debugging
+- Whether to add a test step before the release build
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Release Research
+- `.planning/research/release-automation.md` — Complete workflow YAML templates, create-dmg usage, exit code handling, pre-release pattern, gotchas
+
+### CI Reference (Phase 10)
+- `.github/workflows/ci.yml` — Existing CI workflow with shared patterns (XcodeGen install, xcodebuild flags, xcbeautify, code signing overrides)
+- `.planning/phases/10-ci-pipeline/10-CONTEXT.md` — CI decisions (runner, Homebrew env vars, xcbeautify usage)
+
+### Project Configuration
+- `project.yml` — XcodeGen config with post-build script for version injection from git tags
+
+### Development Guidelines
+- `.github/DEVELOPMENT.md` — Branch protection, PR workflow, release tagging procedures
+
+### Requirements
+- `.planning/REQUIREMENTS.md` §REL — REL-01 (automated build), REL-02 (DMG with layout), REL-03 (upload as asset)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `.github/workflows/ci.yml` — Existing workflow with xcodebuild patterns, Homebrew caching env vars, XcodeGen install, code sign overrides
+- `project.yml` post-build script — Already sets `CFBundleShortVersionString` from `git describe --tags`, so Release builds get the correct version automatically
+
+### Established Patterns
+- `HOMEBREW_NO_AUTO_UPDATE=1` and `HOMEBREW_NO_INSTALL_CLEANUP=1` env vars for faster Homebrew installs
+- `CODE_SIGN_IDENTITY="-"` + `CODE_SIGNING_REQUIRED=NO` + `CODE_SIGNING_ALLOWED=NO` for unsigned builds
+- `xcbeautify --renderer github-actions` for readable CI logs
+- `fetch-depth: 0` required for git describe version script
+
+### Integration Points
+- `.github/workflows/release.yml` — New workflow file
+- `.github/release.yml` — Release notes categorization config
+- GitHub Releases page — Where DMG assets are published
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Version extraction from tag: `echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"`
+- DMG naming convention: `Transy-{version}.dmg` (e.g., `Transy-0.4.0.dmg`)
+- `permissions: contents: write` required for creating releases via `GITHUB_TOKEN`
+- `--verify-tag` flag on `gh release create` as a safety check
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Code signing & notarization** — Add when the app needs broader distribution. Requires Apple Developer certificate, keychain management in CI, `xcrun notarytool`. Significant addition (~50 lines).
+- **CHANGELOG.md** — Manual curated changelog. Consider when auto-generated notes become insufficient.
+
+</deferred>
+
+---
+
+*Phase: 11-release-automation*
+*Context gathered: 2025-07-22*

--- a/.planning/phases/11-release-automation/11-DISCUSSION-LOG.md
+++ b/.planning/phases/11-release-automation/11-DISCUSSION-LOG.md
@@ -1,0 +1,71 @@
+# Phase 11: Release Automation - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2025-07-22
+**Phase:** 11-release-automation
+**Areas discussed:** Trigger Strategy, DMG Creation, Release Notes, Pre-release Support
+
+---
+
+## Trigger Strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Tag push trigger (`on: push: tags: v*`) | Push a tag to trigger the full pipeline: build → DMG → Release creation. Works from CLI or UI. | ✓ |
+| Release event trigger (`on: release: types: [created]`) | Create a Release from GitHub UI first, then workflow builds DMG and uploads to existing Release. | |
+
+**User's choice:** Tag push trigger — workflow creates the GitHub Release automatically
+**Notes:** User selected for full automation. The workflow handles everything end-to-end.
+
+---
+
+## DMG Creation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| create-dmg | Homebrew-installable tool with Finder layout (icon positioning, Applications link). Has exit code 2 gotcha on CI. | ✓ |
+| hdiutil (raw) | Built-in, no dependencies. Functional DMG but no window cosmetics. | |
+| Agent's discretion | Let the agent decide based on research | |
+
+**User's choice:** create-dmg with exit code 2 handling
+**Notes:** None
+
+---
+
+## Release Notes
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Auto-generated + .github/release.yml | PR titles auto-categorized into Features, Bug Fixes, Maintenance, Documentation | ✓ |
+| Auto-generated only | Simple list of PR titles without categorization | |
+| Agent's discretion | Let the agent decide | |
+
+**User's choice:** Auto-generated with category configuration
+**Notes:** None
+
+---
+
+## Pre-release Support
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Pre-release detection | Tags with hyphens (e.g., v0.4.0-beta.1) auto-flagged as pre-release | ✓ |
+| No pre-release support | All tags treated as final releases | |
+
+**User's choice:** Pre-release detection based on tag pattern
+**Notes:** None
+
+---
+
+## Agent's Discretion
+
+- Build approach (xcodebuild build vs archive — research recommends build for unsigned)
+- DMG window dimensions and icon positions
+- Whether to add upload-artifact or test step
+
+## Deferred Ideas
+
+- Code signing & notarization (future phase when broader distribution needed)
+- CHANGELOG.md (when auto-generated notes become insufficient)

--- a/.planning/phases/11-release-automation/11-VERIFICATION.md
+++ b/.planning/phases/11-release-automation/11-VERIFICATION.md
@@ -1,0 +1,132 @@
+---
+phase: 11-release-automation
+verified: 2026-03-29T13:35:48Z
+status: passed
+score: 5/5 must-haves verified
+re_verification: false
+---
+
+# Phase 11: Release Automation — Verification Report
+
+**Phase Goal:** Creating a GitHub Release automatically builds a DMG and uploads it as a release asset
+**Verified:** 2026-03-29T13:35:48Z
+**Status:** ✅ PASSED
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Pushing a v* tag triggers the release workflow | ✓ VERIFIED | `on: push: tags: ['v*']` at lines 3-6; no `on: release` trigger present |
+| 2 | Workflow builds the app in Release configuration | ✓ VERIFIED | `-configuration Release` at line 39; code signing overrides (lines 42-44) match CI patterns; `xcbeautify` piped (line 45) |
+| 3 | Workflow creates a DMG with Transy.app and an Applications drop link | ✓ VERIFIED | `create-dmg` invoked (line 64) with `--app-drop-link 450 190` (line 71), `--volname "Transy"` (line 65), `--no-internet-enable` (line 72); exit code 2 tolerance (lines 63,75-80) |
+| 4 | Workflow creates a GitHub Release with auto-generated categorized notes and the DMG attached | ✓ VERIFIED | `gh release create` (line 95) passes DMG as asset (line 96) with display label, `--generate-notes` (line 98), `--verify-tag` (line 99); `GH_TOKEN` set (line 88); `.github/release.yml` has 5 categories |
+| 5 | Tags with hyphens produce pre-releases | ✓ VERIFIED | Pattern match `*"-"*` on tag name (line 91) sets `--prerelease` flag (line 92) |
+
+**Score:** 5/5 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `.github/workflows/release.yml` | Complete release automation workflow | ✓ VERIFIED | 100 lines; full pipeline: checkout → version extraction → build → verify → DMG → release |
+| `.github/release.yml` | Release notes PR categorization | ✓ VERIFIED | 14 lines; 5 categories: Features, Bug Fixes, Maintenance, Documentation, Other Changes |
+
+**Artifact detail (3-level check):**
+
+| Artifact | Exists | Substantive | Wired | Status |
+|----------|--------|-------------|-------|--------|
+| `.github/workflows/release.yml` | ✓ (100 lines) | ✓ (8 steps, full pipeline) | ✓ (GitHub Actions triggers on tag push) | ✓ VERIFIED |
+| `.github/release.yml` | ✓ (14 lines) | ✓ (5 categories with labels) | ✓ (consumed by `--generate-notes` in workflow) | ✓ VERIFIED |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `.github/workflows/release.yml` | `create-dmg` | brew install + CLI invocation | ✓ WIRED | `brew install xcodegen create-dmg` (line 30) → `create-dmg \` invocation (line 64) with full flags |
+| `.github/workflows/release.yml` | GitHub Releases API | `gh release create` with `--generate-notes` | ✓ WIRED | `gh release create` (line 95) with DMG asset, title, notes generation, verify-tag, and prerelease support |
+| `.github/release.yml` | `.github/workflows/release.yml` | GitHub uses release.yml to categorize `--generate-notes` output | ✓ WIRED | `changelog:` key present in config; workflow passes `--generate-notes` flag which activates this config |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable — these are CI/CD workflow files, not components that render dynamic data.
+
+### Behavioral Spot-Checks
+
+Step 7b: SKIPPED (GitHub Actions workflows cannot be executed locally; they require tag push to GitHub remote to trigger)
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| REL-01 | 11-01-PLAN | Creating a GitHub Release triggers automated build and DMG creation workflow | ✓ SATISFIED | Tag push triggers workflow → xcodebuild Release config build → DMG creation; D-01/D-02 refined trigger to tag-push (workflow creates the release) |
+| REL-02 | 11-01-PLAN | Release workflow creates DMG with drag-to-Applications layout | ✓ SATISFIED | `create-dmg` with `--app-drop-link 450 190`, `--icon "Transy.app" 150 190`, `--hide-extension`, `--volname "Transy"` |
+| REL-03 | 11-01-PLAN | Release workflow uploads DMG as a Release asset | ✓ SATISFIED | DMG passed as positional arg to `gh release create` with display label `#Transy {version} (macOS)` |
+
+**Orphaned requirements check:** REQUIREMENTS.md maps REL-01, REL-02, REL-03 to Phase 11. Plan claims REL-01, REL-02, REL-03. No orphaned requirements. ✓
+
+**Note on REL-01 wording:** REQUIREMENTS.md says "Creating a GitHub Release triggers..." but per decisions D-01/D-02, the flow is reversed: pushing a v* tag triggers the workflow which then creates the GitHub Release. This is a deliberate, documented design decision (tag-push trigger is more reliable than `on: release` event). The requirement is satisfied in spirit — the automated build-and-release pipeline works; only the trigger mechanism was refined.
+
+### CI Pattern Consistency
+
+| Pattern | CI Workflow | Release Workflow | Match |
+|---------|-------------|------------------|-------|
+| `HOMEBREW_NO_AUTO_UPDATE: 1` | Line 12 | Line 12 | ✓ |
+| `HOMEBREW_NO_INSTALL_CLEANUP: 1` | Line 13 | Line 13 | ✓ |
+| `CODE_SIGN_IDENTITY="-"` | Lines 53, 63 | Line 42 | ✓ |
+| `CODE_SIGNING_REQUIRED=NO` | Lines 54, 64 | Line 43 | ✓ |
+| `CODE_SIGNING_ALLOWED=NO` | Lines 55, 65 | Line 44 | ✓ |
+| `xcbeautify --renderer github-actions` | Lines 56, 66 | Line 45 | ✓ |
+| `fetch-depth: 0` | Line 39 | Line 23 | ✓ |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| — | — | None found | — | — |
+
+Both files are clean: no TODOs, FIXMEs, placeholders, empty implementations, or console.log stubs.
+
+### YAML Validity
+
+No tabs found in either file (tabs are invalid YAML). Both files have proper indentation structure. Python `yaml` module unavailable for full parse validation, but manual inspection and GitHub Actions' own YAML parser will validate on first run.
+
+### Commit Verification
+
+| Commit | Message | Status |
+|--------|---------|--------|
+| `26d09a2` | feat(11-01): add release notes categorization config | ✓ EXISTS |
+| `f948033` | feat(11-01): add release workflow for automated DMG builds | ✓ EXISTS |
+
+### Human Verification Required
+
+### 1. End-to-End Release Pipeline
+
+**Test:** Push a test tag: `git tag v0.4.0-test.1 && git push origin v0.4.0-test.1`
+**Expected:** Workflow triggers, builds Transy in Release config, creates a DMG, publishes a pre-release (hyphenated tag) on GitHub Releases with the DMG attached and auto-generated notes.
+**Why human:** GitHub Actions workflow cannot be triggered locally; requires actual tag push to remote.
+
+### 2. DMG Layout
+
+**Test:** Download the DMG from the GitHub Release and open it.
+**Expected:** DMG opens with Transy.app icon on the left and an Applications folder alias on the right, in a clean drag-to-install layout.
+**Why human:** Visual verification of DMG layout requires mounting and viewing the disk image.
+
+### 3. Release Notes Categorization
+
+**Test:** After creating a release with PRs in the history, check the release notes.
+**Expected:** PRs are grouped into "✨ Features", "🐛 Bug Fixes", "🔧 Maintenance", "📖 Documentation", and "Other Changes" sections based on their labels.
+**Why human:** Requires actual PRs with labels in the repository to verify categorization.
+
+### Gaps Summary
+
+No gaps found. All 5 observable truths are verified. All 3 requirements (REL-01, REL-02, REL-03) are satisfied. Both artifacts exist, are substantive, and are properly wired. No anti-patterns detected. CI workflow patterns are consistently mirrored.
+
+The only item requiring human follow-up is the end-to-end test of the workflow via an actual tag push to GitHub, which is expected for any CI/CD workflow that can't be invoked locally.
+
+---
+
+_Verified: 2026-03-29T13:35:48Z_
+_Verifier: the agent (gsd-verifier)_


### PR DESCRIPTION
## Summary

Add GitHub Actions release workflow that builds, packages, and publishes DMG artifacts when version tags are pushed.

### Changes

- **`.github/workflows/release.yml`** — Release workflow triggered by `v*` tag push
  - Builds app in Release configuration via xcodebuild
  - Creates DMG with drag-to-Applications layout via `create-dmg`
  - Handles `create-dmg` exit code 2 (cosmetic failures) gracefully
  - Creates GitHub Release with auto-generated notes and DMG asset
  - Pre-release detection for hyphenated tags (e.g., `v0.4.0-beta.1`)
- **`.github/release.yml`** — Release notes categorization config
  - Features, Bug Fixes, Maintenance, Documentation, Other Changes

### Requirements

- Closes #16
- Relates to #14

### Testing

End-to-end test requires pushing a tag (e.g., `git tag v0.4.0-test.1 && git push origin v0.4.0-test.1`) after merge.