### PR TITLE
docs: address PR #25 review comments

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,22 @@
 # Milestones
 
+## v0.4.0 DevOps & Improvements (Shipped: 2026-04-04)
+
+**Phases completed:** 4 phases, 6 plans
+**Timeline:** 10 days (2026-03-25 → 2026-04-04)
+**Codebase:** ~1,700 LOC Swift (app + tests)
+
+**Key accomplishments:**
+- CI pipeline with SwiftLint, SwiftFormat, build and test on every PR (macos-15)
+- Release automation: git tag push → Release build → DMG → GitHub Release with auto-generated notes
+- Permission-free clipboard monitoring (NSPasteboard changeCount polling) replaces Double ⌘C — no Accessibility permission needed
+- Framework-native translation model download UI removes manual System Settings guidance
+- Preflight language detection removed — eliminated redundant ML inference per translation
+
+**Archives:** [milestones/v0.4.0-ROADMAP.md](milestones/v0.4.0-ROADMAP.md) · [milestones/v0.4.0-REQUIREMENTS.md](milestones/v0.4.0-REQUIREMENTS.md)
+
+---
+
 ## v0.3.0 Onboarding & Settings (Shipped: 2026-03-25)
 
 **Phases completed:** 3 phases, 3 plans

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -16,15 +16,15 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-25)
+See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
-**Current focus:** Phase 13 — translation-download-ui
+**Current focus:** v0.4.0 complete — awaiting next milestone
 
 ## Current Position
 
-Phase: 13
-Plan: Not started
+Milestone v0.4.0 archived. No active phase.
+Next step: `/gsd-new-milestone` to start v0.5.0.
 
 ## Performance Metrics
 

--- a/.planning/milestones/v0.4.0-REQUIREMENTS.md
+++ b/.planning/milestones/v0.4.0-REQUIREMENTS.md
@@ -24,7 +24,7 @@
 ### Clipboard Monitoring
 
 - [x] **CLB-01**: Clipboard monitoring detects new text via NSPasteboard.general.changeCount polling
-- [~] **CLB-02**: ~~User can select trigger mode in Settings (clipboard monitoring vs double ⌘C)~~ — **Adjusted**: implemented as clipboard-only mode; Double ⌘C removed entirely with no mode picker. Simpler and permission-free.
+- [x] **CLB-02**: ~~User can select trigger mode in Settings (clipboard monitoring vs double ⌘C)~~ — **Adjusted**: implemented as clipboard-only mode; Double ⌘C removed entirely with no mode picker. Simpler and permission-free.
 - [x] **CLB-03**: Clipboard monitoring skips concealed and transient pasteboard types
 - [x] **CLB-04**: Self-originated clipboard changes are ignored to prevent re-trigger loops
 
@@ -58,4 +58,4 @@
 
 ---
 
-*For current requirements, see .planning/REQUIREMENTS.md (next milestone)*
+*For current requirements, see the active milestone requirements document under `.planning/milestones/`, or use `/gsd-new-milestone` to create requirements for the next milestone.*

--- a/.planning/milestones/v0.4.0-ROADMAP.md
+++ b/.planning/milestones/v0.4.0-ROADMAP.md
@@ -42,7 +42,7 @@ Plans:
 - Tag push trigger (`on: push: tags: [v*]`)
 - create-dmg via Homebrew for drag-to-Applications DMG layout; exit code 2 tolerated (warnings only)
 - Auto-generated release notes via `gh release create --generate-notes` with PR categorization from `.github/release.yml`
-- xcconfig approach for version: `postBuildScript` writes git tag to `Config/Version.xcconfig`
+- xcconfig approach for version: `preBuildScripts` writes git tag to `Config/Version.xcconfig`
 
 ### Phase 12: Clipboard Monitoring
 


### PR DESCRIPTION
Fixes 5 review comments from PR #25 (already merged).

- **STATE.md**: Remove stale in-progress sections; reflect archived milestone state
- **MILESTONES.md**: Add v0.4.0 entry with key accomplishments and archive links
- **v0.4.0-ROADMAP.md**: Fix `postBuildScript` → `preBuildScripts` (matches project.yml)
- **v0.4.0-REQUIREMENTS.md**: Fix `[~]` → `[x]` for CLB-02 (invalid GitHub checkbox)
- **v0.4.0-REQUIREMENTS.md**: Fix dead reference to deleted `REQUIREMENTS.md`

Relates to #14