### PR TITLE
docs: start milestone v0.5.0 Translation Quality

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -24,15 +24,14 @@ Selected text turns into a natural translation almost instantly without breaking
 **Tech stack:** SwiftUI, AppKit, Apple Translation.framework, ServiceManagement.framework, XcodeGen
 **Code:** ~1,700 LOC Swift (app + tests), 50+ automated tests
 
-## Next Milestone Goals
+## Current Milestone: v0.5.0 Translation Quality
 
-TBD — to be defined with `/gsd-new-milestone`
+**Goal:** すべての言語ペアで翻訳を動作させ、体感速度と視覚的フィードバックを改善する
 
-Candidates from backlog:
-- Multi-language support (language pairs beyond JP/EN)
-- Translation history / recent translations
-- Code signing and notarization for broader distribution
-- Popup customization (font size, theme)
+**Target features:**
+- English pivot translation — Apple Translation がサポートしないペア（例：JP→DE）をEN経由で中継
+- Shimmer animation — 翻訳中のロード状態をskeleton shimmerで視覚化
+- Chunked translation — 200文字単位で分割して並列翻訳、長文の高速化
 
 ## Constraints
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -26,12 +26,12 @@ Selected text turns into a natural translation almost instantly without breaking
 
 ## Current Milestone: v0.5.0 Translation Quality
 
-**Goal:** すべての言語ペアで翻訳を動作させ、体感速度と視覚的フィードバックを改善する
+**Goal:** Make all language pairs work and improve perceived speed and visual feedback during translation
 
 **Target features:**
-- English pivot translation — Apple Translation がサポートしないペア（例：JP→DE）をEN経由で中継
-- Shimmer animation — 翻訳中のロード状態をskeleton shimmerで視覚化
-- Chunked translation — 200文字単位で分割して並列翻訳、長文の高速化
+- English pivot translation — relay unsupported pairs (e.g. JP→DE) through English when Apple Translation has no direct model
+- Shimmer animation — visualize translation loading state with a skeleton shimmer overlay
+- Chunked translation — batch-translate up to 200-char sentence chunks via `translations(from:)`, speeding up long texts
 
 ## Constraints
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,21 +9,21 @@ Requirements for Translation Quality milestone. Each maps to roadmap phases.
 
 ### Shimmer Animation
 
-- [ ] **SHM-01**: 翻訳中（loading状態）にshimmer/skeleton animationが表示される
-- [ ] **SHM-02**: Shimmerはzero-layout-impact（NSPanelのリサイズを誘発しない）
-- [ ] **SHM-03**: Reduce Motionが有効な場合はshimmerを無効化し静的表示にフォールバック
+- [ ] **SHM-01**: Translation loading state shows a shimmer/skeleton animation
+- [ ] **SHM-02**: Shimmer is zero-layout-impact (does not trigger NSPanel resize)
+- [ ] **SHM-03**: Shimmer is disabled and falls back to static display when Reduce Motion is enabled
 
 ### Chunked Translation
 
-- [ ] **CHK-01**: テキストが200文字を超える場合、文章境界で分割して翻訳する（NLTokenizer使用）
-- [ ] **CHK-02**: translations(from:) バッチAPIを使用し、結果を入力順に結合する
-- [ ] **CHK-03**: 200文字以下のテキストは分割せず直接翻訳する（short-text bypass）
+- [ ] **CHK-01**: Text longer than 200 characters is split at sentence boundaries (NLTokenizer) before translation
+- [ ] **CHK-02**: Batch `translations(from:)` API is used; results are joined in input order
+- [ ] **CHK-03**: Text of 200 characters or fewer bypasses chunking and is translated directly (short-text bypass)
 
 ### Pivot Translation
 
-- [ ] **PIV-01**: unsupportedLanguagePairingエラー検出時に、source→EN→targetの2段階翻訳にフォールバックする
-- [ ] **PIV-02**: Pivot中もshimmerが継続表示される（ユーザーにはシームレスに見える）
-- [ ] **PIV-03**: Pivot失敗（EN経由でも不可）の場合は適切なエラーメッセージを表示する
+- [ ] **PIV-01**: On `unsupportedLanguagePairing` error, automatically falls back to a source→EN→target two-leg chain
+- [ ] **PIV-02**: Shimmer continues throughout the entire pivot sequence (seamless to the user)
+- [ ] **PIV-03**: If the pivot also fails (EN path unavailable), an appropriate error message is shown
 
 ## Future Requirements
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,64 @@
+# Requirements: Transy
+
+**Defined:** 2026-04-04
+**Core Value:** Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
+
+## v0.5.0 Requirements
+
+Requirements for Translation Quality milestone. Each maps to roadmap phases.
+
+### Shimmer Animation
+
+- [ ] **SHM-01**: 翻訳中（loading状態）にshimmer/skeleton animationが表示される
+- [ ] **SHM-02**: Shimmerはzero-layout-impact（NSPanelのリサイズを誘発しない）
+- [ ] **SHM-03**: Reduce Motionが有効な場合はshimmerを無効化し静的表示にフォールバック
+
+### Chunked Translation
+
+- [ ] **CHK-01**: テキストが200文字を超える場合、文章境界で分割して翻訳する（NLTokenizer使用）
+- [ ] **CHK-02**: translations(from:) バッチAPIを使用し、結果を入力順に結合する
+- [ ] **CHK-03**: 200文字以下のテキストは分割せず直接翻訳する（short-text bypass）
+
+### Pivot Translation
+
+- [ ] **PIV-01**: unsupportedLanguagePairingエラー検出時に、source→EN→targetの2段階翻訳にフォールバックする
+- [ ] **PIV-02**: Pivot中もshimmerが継続表示される（ユーザーにはシームレスに見える）
+- [ ] **PIV-03**: Pivot失敗（EN経由でも不可）の場合は適切なエラーメッセージを表示する
+
+## Future Requirements
+
+- Translation history / recent translations
+- Code signing and notarization for broader distribution
+- Popup customization (font size, theme)
+- Translation cancellation latency improvement (requires macOS 26+)
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| "Translating via English…" progress label | Exposes internal pivot logic needlessly; users don't need to know the implementation |
+| Parallel chunk TaskGroup | Over-engineered; `translations(from:)` batch API handles ordering and likely parallelizes internally |
+| Per-chunk error recovery | Two real failure modes (unsupported pair → pivot, transient → error message) handled at whole-request level |
+| Proactive LanguageAvailability.status() preflight | Removed in v0.4.0 to avoid double ML inference; keep the error-driven pivot approach |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| SHM-01 | Phase 14 | Pending |
+| SHM-02 | Phase 14 | Pending |
+| SHM-03 | Phase 14 | Pending |
+| CHK-01 | Phase 15 | Pending |
+| CHK-02 | Phase 15 | Pending |
+| CHK-03 | Phase 15 | Pending |
+| PIV-01 | Phase 16 | Pending |
+| PIV-02 | Phase 16 | Pending |
+| PIV-03 | Phase 16 | Pending |
+
+**Coverage:**
+- v0.5.0 requirements: 9 total
+- Mapped to phases: 9
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-04-04*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -6,6 +6,7 @@
 - ✅ **v0.2.0 Popup UX Polish** — Phases 5-6 (shipped 2026-03-21)
 - ✅ **v0.3.0 Onboarding & Settings** — Phases 7-9 (shipped 2026-03-25)
 - ✅ **v0.4.0 DevOps & Improvements** — Phases 10-13 (shipped 2026-04-04)
+- 🚧 **v0.5.0 Translation Quality** — Phases 14-16 (in progress)
 
 ## Phases
 
@@ -54,9 +55,50 @@ Full details: [milestones/v0.4.0-ROADMAP.md](milestones/v0.4.0-ROADMAP.md)
 
 </details>
 
+### 🚧 v0.5.0 Translation Quality
+
+- [ ] **Phase 14: Shimmer Animation** — Animated skeleton shimmer during translation loading state
+- [ ] **Phase 15: Chunked Translation** — Split long text at sentence boundaries and translate as a batch
+- [ ] **Phase 16: Pivot Translation** — Chain source→EN→target when language pair is unsupported
+
 ## Phase Details
 
-<!-- Next milestone phases will be added here -->
+### 🚧 v0.5.0 Translation Quality
+
+### Phase 14: Shimmer Animation
+**Goal**: Users see a smooth animated skeleton shimmer while translation is in progress, with no jarring layout shifts
+**Depends on**: Phase 13
+**Requirements**: SHM-01, SHM-02, SHM-03
+**Success Criteria** (what must be TRUE):
+  1. A shimmer animation plays over the loading-state text from the moment translation begins until the result appears
+  2. Showing or hiding the shimmer does not change the popup's layout dimensions (no resize notification storm)
+  3. When System Preferences → Accessibility → Reduce Motion is enabled, the shimmer is replaced with a static placeholder — no animation plays
+**Plans**: TBD (estimated 2 plans)
+**UI hint**: yes
+
+---
+
+### Phase 15: Chunked Translation
+**Goal**: Texts longer than 200 characters are split at sentence boundaries and translated as a single batch, returning a correctly ordered result
+**Depends on**: Phase 14
+**Requirements**: CHK-01, CHK-02, CHK-03
+**Success Criteria** (what must be TRUE):
+  1. A text of 201+ characters is split into sentence-boundary chunks via `NLTokenizer` and all chunks are submitted as one `translations(from:)` batch call
+  2. The translated chunks are recombined in input order — the result reads as continuous prose regardless of chunk count
+  3. A text of ≤200 characters is translated directly without any chunking (single-call path, no overhead)
+**Plans**: TBD (estimated 2 plans)
+
+---
+
+### Phase 16: Pivot Translation
+**Goal**: When Apple Translation reports an unsupported language pair, the app silently chains two translations through English so the user still gets a result
+**Depends on**: Phase 15
+**Requirements**: PIV-01, PIV-02, PIV-03
+**Success Criteria** (what must be TRUE):
+  1. Translating a language pair not supported by Apple Translation (e.g. JP→DE) produces a correct result via the source→EN→target chain — no error shown to the user
+  2. The shimmer animation plays continuously across both pivot legs — the popup never flickers or shows a partial state between legs
+  3. When the pivot path also fails (EN→target unsupported), a clear error message is displayed instead of a blank or crashed popup
+**Plans**: TBD (estimated 2 plans)
 
 ## Progress
 
@@ -75,7 +117,10 @@ Full details: [milestones/v0.4.0-ROADMAP.md](milestones/v0.4.0-ROADMAP.md)
 | 11. Release Automation | v0.4.0 | 1/1 | Complete | 2026-03-29 |
 | 12. Clipboard Monitoring | v0.4.0 | 2/2 | Complete | 2026-04-04 |
 | 13. Translation Download UI | v0.4.0 | 1/1 | Complete | 2026-04-04 |
+| 14. Shimmer Animation | v0.5.0 | 0/2 | Not started | — |
+| 15. Chunked Translation | v0.5.0 | 0/2 | Not started | — |
+| 16. Pivot Translation | v0.5.0 | 0/2 | Not started | — |
 
 ---
 
-*Last updated: 2026-04-04 — v0.4.0 shipped*
+*Last updated: 2026-04-04 — v0.5.0 roadmap created (phases 14-16)*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,88 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.4.0
-milestone_name: DevOps & Improvements
-status: "v0.4.0 SHIPPED — milestone complete"
-stopped_at: Milestone archived
-last_updated: "2026-04-04T08:00:00.000Z"
+milestone: v0.5.0
+milestone_name: Translation Quality
+status: "Defining requirements"
+stopped_at: Milestone started
+last_updated: "2026-04-04T09:00:00.000Z"
 progress:
-  total_phases: 4
-  completed_phases: 4
-  total_plans: 6
-  completed_plans: 6
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
 ---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-04)
+
+**Core value:** Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
+**Current focus:** v0.5.0 Translation Quality — defining requirements
+
+## Current Position
+
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-04-04 — Milestone v0.5.0 started
+
+## Performance Metrics
+
+**Velocity (v0.1.0):**
+
+- Total plans completed: 9
+- Average duration: 26.1 min
+- Total execution time: 199 min
+
+**Velocity (v0.2.0):**
+
+- Total plans completed: 4
+- Average duration: 3.5 min
+- Total execution time: 14.1 min
+
+| Phase | Plan | Duration | Tasks | Files | Completed |
+|-------|------|----------|-------|-------|-----------|
+| 05    | 00   | 103s (1.7m) | 1     | 3     | 2026-03-16T14:55:14Z |
+| 06    | 00   | 97s (1.6m)  | 2     | 2     | 2026-03-20T16:46:31Z |
+| 06    | 01   | 480s (8.0m) | 2     | 1     | 2026-03-20T16:58:43Z |
+| 08    | 01   | 72s (1.2m)  | 2     | 2     | 2026-03-23T13:21:00Z |
+| Phase 10-ci-pipeline P02 | 65 | 1 tasks | 1 files |
+| Phase 10 P01 | 88 | 2 tasks | 5 files |
+| Phase 11 P01 | 98 | 2 tasks | 2 files |
+| Phase 13 P01 | 348 | 2 tasks | 11 files |
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- [v0.4.0]: Clipboard monitoring replaces Double ⌘C — no Accessibility permission required
+- [v0.4.0]: Framework-native translation model download — no manual System Settings guidance
+- [v0.4.0]: Preflight LanguageAvailability.status() removed — TranslationErrorMapper handles all errors
+- [v0.4.0]: TextNormalization as enum namespace (normalized(), detectionSample(from:))
+- [v0.1.0]: Apple Translation framework chosen as backend — on-device speed, privacy, macOS-native integration
+- [v0.1.0]: Popup is NSPanel with `.nonactivatingPanel` styleMask — SwiftUI `WindowGroup` is a hard anti-pattern
+- [v0.1.0]: `project.yml` managed by xcodegen is the single source of truth for `Transy.xcodeproj`
+
+### Pending Todos
+
+- Todo: track unresolved Translation framework cancellation latency across re-trigger/dismiss flows (deferred — Apple framework limitation on macOS 15; revisit when macOS 26 adoption grows)
+
+### Blockers/Concerns
+
+- Known limitation: Translation framework cancellation latency can still make a short request feel delayed after a longer one (macOS 15 limitation)
+- Apple Translation framework requires macOS 15+ — hard deployment-target floor
+- Not all language pairs supported by Apple Translation — v0.5.0 addresses this with English pivot
+
+## Session Continuity
+
+Last session: 2026-04-04
+Stopped at: v0.5.0 milestone started — defining requirements
+Resume file: None
 
 # Project State
 

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,8 +1,285 @@
 # Architecture Research
 
 **Domain:** macOS menu bar utility — selected-text translation
-**Researched:** 2026-03-14
-**Confidence:** HIGH
+**Researched:** 2026-04-06 (updated for v0.5.0)
+**Confidence:** HIGH (existing code direct-read); MEDIUM (Apple Translation multi-session concurrency)
+
+---
+
+## v0.5.0 Integration Research
+
+This section documents the integration design for the three v0.5.0 features against the existing v0.4.0 architecture. It answers: which files to create vs. modify, where each feature's logic lives, build order, and Swift 6 concurrency constraints.
+
+---
+
+### Existing Architecture (v0.4.0 reference)
+
+```text
+AppDelegate (@MainActor)
+  │  owns: ClipboardMonitor, PopupController, TranslationCoordinator, SettingsStore
+  │
+  ├─ ClipboardMonitor.start { text → handleTrigger(text:) }
+  │
+  └─ handleTrigger(text:)
+       │  TextNormalization.normalized(text)
+       │  translationCoordinator.begin(sourceText:)   → popupState = .loading(requestID, sourceText)
+       │  popupController.show(translationCoordinator:, targetLanguage:, onDismiss:)
+       └─ on dismiss → translationCoordinator.dismiss()
+
+PopupController (@MainActor)
+  │  owns: NSPanel, dismiss monitors, resize observer
+  └─ show() → creates PopupView wrapped in NSHostingView
+               sets panel.contentView = hostingView
+
+PopupView (SwiftUI struct)
+  │  observes: translationCoordinator.popupState (via @Observable)
+  ├─ .loading  → LoadingPopupText (owns translationTask + session)
+  ├─ .result   → PopupText(translatedText)
+  └─ .error    → PopupText(message)
+
+LoadingPopupText (private SwiftUI struct)
+  │  @State translationConfiguration: TranslationSession.Configuration?
+  ├─ body: PopupText(sourceText, isMuted: true)   ← source text as loading placeholder
+  ├─ .onChange(requestID) → nextTranslationConfiguration()
+  └─ .translationTask(configuration, action: translationAction)
+       └─ translationAction(session):
+            try await session.translate(sourceText)
+            → onResult / onError callbacks
+            → PopupView calls translationCoordinator.finish() / .fail()
+
+TranslationCoordinator (@MainActor @Observable)
+  │  State machine: hidden → loading → result/error → hidden
+  │  activeRequestID: UUID? (stale-request guard)
+  └─ begin / finish / fail / dismiss
+```
+
+---
+
+### Feature 1: English Pivot Translation
+
+#### Problem
+`TranslationError.unsupportedLanguagePairing` is already caught in `LoadingPopupText.translationAction` and routed to `onError`. For pivot, instead of failing, we need to chain two `TranslationSession` calls: source→English, then English→target.
+
+#### Root constraint: one `.translationTask` per session config
+Apple's `.translationTask(configuration:action:)` creates one `TranslationSession` for the configured pair. To do pivot, we need two sessions with different pairs. The mechanism is `configuration.invalidate()`, which already exists (`nextTranslationConfiguration()`) — it causes SwiftUI to tear down the current session and start a new one.
+
+#### Architecture decision: local pivot state in `LoadingPopupText`
+Pivot state is a translation engine implementation detail, not a coordinator concern. `TranslationCoordinator` stays unchanged. A new `@MainActor @Observable` helper class `PivotTranslationState` holds the phase and is owned by `LoadingPopupText` via `@State`.
+
+This mirrors the existing pattern: `TranslationCoordinator` is an `@Observable` class owned via `@State` equivalent. `PivotTranslationState` plays the same role for intra-translation pivot phases.
+
+```text
+PivotPhase enum (new, in PivotTranslationState.swift):
+  .direct                              ← initial state
+  .firstLeg                            ← source→EN in progress
+  .secondLeg(intermediate: String)     ← EN→target in progress, intermediate cached
+```
+
+#### Data flow (pivot enabled)
+
+```text
+translationAction called with session configured (source: nil, target: targetLanguage)
+  │
+  ├─ success → onResult (normal path, no change)
+  │
+  └─ catch TranslationError.unsupportedLanguagePairing
+       │
+       └─ await MainActor.run { pivotState.phase = .firstLeg }
+            │
+            └─ .onChange(pivotState.phase) fires → nextTranslationConfiguration(target: .english)
+                 │
+                 └─ translationAction called again with session (source: nil, target: English)
+                      │
+                      ├─ success (intermediate English text)
+                      │    └─ await MainActor.run { pivotState.phase = .secondLeg(intermediate) }
+                      │         └─ .onChange → nextTranslationConfiguration(target: targetLanguage)
+                      │              └─ translationAction called with session (source: English, target: targetLanguage)
+                      │                   ├─ translate(intermediate)  ← uses cached intermediate, NOT sourceText
+                      │                   └─ success → onResult
+                      │
+                      └─ failure → onError (pivot leg 1 also failed)
+```
+
+#### Integration points
+
+| File | Change |
+|------|--------|
+| `Transy/Translation/PivotTranslationState.swift` | **NEW** — `@MainActor @Observable final class PivotTranslationState` with `PivotPhase` enum |
+| `Transy/Popup/PopupView.swift` | **MODIFY** `LoadingPopupText`: add `@State private var pivotState = PivotTranslationState()`, extend `.onChange` to also react to `pivotState.phase`, extend `translationAction` to accept `onPivotNeeded` callback and dispatch phase transitions |
+| `Transy/Translation/TranslationErrorMapper.swift` | **MODIFY** — expose `static func isPivotableError(_ error: any Error) -> Bool` (extracted from existing `.unsupportedLanguagePairing` match in `message(for:)`) |
+| `TranslationCoordinator.swift` | **NO CHANGE** |
+| `AppDelegate.swift` | **NO CHANGE** |
+| `PopupController.swift` | **NO CHANGE** |
+
+#### Swift 6 concurrency notes
+- `translationAction` is `nonisolated static` — all `@Sendable` callback closures must route MainActor mutations through `await MainActor.run {}`
+- `PivotTranslationState` is `@MainActor`-isolated, so it is `Sendable` as a reference type — safe to capture in `@Sendable` closures
+- `PivotPhase` must be `Sendable` — it contains only `String` (Sendable) so it qualifies
+- The `translationAction` signature gains one more `@escaping @Sendable` callback param, matching the existing `onResult`/`onError` pattern
+
+#### Risk: Are multiple sequential `.translationTask` invocations safe?
+The existing `nextTranslationConfiguration()` + `configuration.invalidate()` mechanism is already used for each new clipboard copy. Pivot reuses the same mechanism for 2-3 consecutive invalidations within a single user trigger. No new framework surface is exercised — confidence HIGH.
+
+---
+
+### Feature 2: Shimmer Animation
+
+#### Problem
+During `.loading`, `LoadingPopupText` shows `PopupText(text: sourceText, isMuted: true)` — static muted text. The shimmer replaces or augments this with an animated gradient overlay that signals "translation in progress" more clearly.
+
+#### Architecture decision: isolated view modifier, no state changes
+Shimmer is pure visual state: it is "on" whenever `popupState == .loading` and "off" otherwise. No new state is needed in `TranslationCoordinator` or anywhere else — the fact that `LoadingPopupText` is rendered at all is the signal.
+
+```text
+ShimmerModifier (new, in ShimmerModifier.swift):
+  @State private var animating = false
+  body: ZStack {
+    content
+    shimmerOverlay   ← LinearGradient masked to content shape, animated horizontally
+  }
+  .onAppear { withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) { animating = true } }
+```
+
+The shimmer gradient slides from `startX = -bounds.width` to `endX = +bounds.width` using a phase offset driven by `animating`. On macOS, prefer `Color.white.opacity(0.25)` peak (dark material background from `PopupText` is `.regularMaterial`) — validate on both light and dark menu bar configurations.
+
+#### Integration points
+
+| File | Change |
+|------|--------|
+| `Transy/Popup/ShimmerModifier.swift` | **NEW** — `ShimmerModifier: ViewModifier` + `View.shimmer()` extension |
+| `Transy/Popup/PopupView.swift` | **MODIFY** `LoadingPopupText.body`: add `.shimmer()` modifier on `PopupText(sourceText, isMuted: true)` |
+| All other files | **NO CHANGE** |
+
+#### Swift 6 concurrency notes
+- `ShimmerModifier` is a pure SwiftUI struct — no actor isolation needed
+- `@State` animation is entirely main-thread; no concurrency surface
+
+#### Risk: none — most isolated of the three features
+
+---
+
+### Feature 3: Chunked Translation
+
+#### Problem
+Texts > 200 chars may be split into smaller units that the Apple Translation framework handles better. Each chunk must be translated in order, then joined.
+
+#### Architecture decision: new `TextChunker` utility, modify `translationAction`
+Chunking is a text preparation concern, parallel to existing `TextNormalization`. It belongs in `Transy/Translation/` as a pure, stateless utility.
+
+```text
+TextChunker (new, in TextChunker.swift):
+  static func chunks(from text: String, maxLength: Int = 200) -> [String]
+    │
+    ├─ if text.count <= maxLength → [text]   (fast path, no allocation)
+    │
+    └─ split at sentence-final punctuation followed by whitespace/end
+         boundary chars: 。.!?！？\n (in priority order)
+         if a sentence exceeds maxLength alone → split at last word boundary ≤ maxLength
+         never split a unicode scalar mid-codepoint
+```
+
+`translationAction` in `LoadingPopupText` becomes:
+```swift
+let chunks = TextChunker.chunks(from: requestContext.sourceText)
+var assembled: [String] = []
+for chunk in chunks {
+    let response = try await session.translate(chunk)
+    assembled.append(response.targetText)
+}
+await onResult(requestID, sourceText, assembled.joined(separator: " "))
+```
+
+Sequential (not parallel) because:
+1. It is undocumented whether multiple concurrent `session.translate()` calls on the same `TranslationSession` are safe — Apple docs show single-call examples only (confidence: LOW that parallel is safe)
+2. Sequential preserves insertion order trivially
+3. Apple's on-device ML pipeline may internally batch — actual latency gain from parallelism is unclear
+
+#### Integration with pivot (combined path)
+When both pivot and chunking apply (text > 200 chars AND unsupported language pair):
+- Leg 1 action: chunks source text into ≤200-char pieces → translates each to English → joins as `intermediateText`
+- Leg 2 action: `TextChunker.chunks(from: intermediateText)` → translates each to target → joins as final result
+- No special coordination needed: `TextChunker.chunks()` is always called inside `translationAction`, and the action is re-executed for each pivot leg
+
+#### Integration points
+
+| File | Change |
+|------|--------|
+| `Transy/Translation/TextChunker.swift` | **NEW** — `enum TextChunker` with `static func chunks(from:maxLength:) -> [String]` |
+| `Transy/Popup/PopupView.swift` | **MODIFY** `LoadingPopupText.translationAction`: replace single `session.translate(sourceText)` with chunk loop |
+| `TextNormalization.swift` | **NO CHANGE** — `TextNormalization.normalized()` runs before chunking in `AppDelegate.handleTrigger()`; chunking happens inside the translation action |
+| All other files | **NO CHANGE** |
+
+#### Swift 6 concurrency notes
+- `TextChunker` is a pure `enum` with static methods — no actor isolation, fully `Sendable`
+- The for-loop `try await session.translate(chunk)` runs in the existing `nonisolated` action closure — no new concurrency surface
+
+#### Risk: sentence-boundary algorithm correctness
+Mixed-language text (Japanese + English) needs boundary detection that handles both `。` and `.`. Unicode sentence segmentation via `NaturalLanguage.NLTokenizer(unit: .sentence)` would be more correct than manual punctuation splitting, but adds a framework dependency. Recommend starting with punctuation-based splitting and adding NLTokenizer if edge cases emerge.
+
+---
+
+### Component Summary
+
+#### New files
+
+| File | Purpose | Feature |
+|------|---------|---------|
+| `Transy/Translation/PivotTranslationState.swift` | `PivotPhase` enum + `@Observable @MainActor` class holding pivot phase | Pivot |
+| `Transy/Popup/ShimmerModifier.swift` | Animated shimmer `ViewModifier` + `View.shimmer()` extension | Shimmer |
+| `Transy/Translation/TextChunker.swift` | Sentence-boundary chunking utility | Chunked |
+
+#### Modified files
+
+| File | What changes | Features |
+|------|-------------|---------|
+| `Transy/Popup/PopupView.swift` | `LoadingPopupText`: pivot state, shimmer overlay, chunk loop in action | All 3 |
+| `Transy/Translation/TranslationErrorMapper.swift` | Extract `isPivotableError(_:)` from existing logic | Pivot |
+
+#### Unchanged files
+
+| File | Reason |
+|------|--------|
+| `AppDelegate.swift` | Trigger flow unchanged; all new logic is below coordinator level |
+| `PopupController.swift` | NSPanel lifecycle unchanged |
+| `TranslationCoordinator.swift` | State machine unchanged; pivot is encapsulated in LoadingPopupText |
+| `TextNormalization.swift` | Chunking is separate from normalization |
+
+---
+
+### Build Order
+
+```
+1. TextChunker (most independent)
+   └─ Pure utility, testable in isolation, no UI surface
+   └─ Required by: pivot leg 1+2 actions when combined with long text
+
+2. ShimmerModifier (UI only)
+   └─ Zero logic dependencies, zero state changes
+   └─ Can be developed + reviewed independently at any time
+
+3. English Pivot (most complex, build last)
+   └─ Depends on: TranslationErrorMapper.isPivotableError() (extracted from existing code)
+   └─ Depends on: TextChunker existing (for combined pivot+chunked path)
+   └─ Integration risk is highest; benefits from having shimmer already in place
+      (shimmer continues to work correctly during multi-leg pivot loading state)
+```
+
+**Rationale for this order:**
+- Chunked translation is functionally independent and its test suite validates `TextChunker` without any Translation framework dependency
+- Shimmer is a visual polish feature; shippable by itself; being live before pivot means the UI looks correct during all pivot phases automatically (pivot stays in `.loading` state throughout both legs — shimmer keeps animating correctly)
+- Pivot builds on a correct chunked-action and a ready shimmer; its complexity is contained to `LoadingPopupText` + `PivotTranslationState`
+
+---
+
+### Integration Risk Summary
+
+| Risk | Severity | Mitigation |
+|------|---------|-----------|
+| `TranslationSession` concurrent `translate()` calls undocumented | MEDIUM | Use sequential chunk translation; investigate parallel only if latency is a measured issue |
+| Pivot second-leg config invalidation races with user's rapid re-copy | LOW | `activeRequestID` guard in `TranslationCoordinator` already handles stale requests; pivot phase resets on new `requestID` via `.onChange(requestContext.requestID, initial: true)` |
+| Shimmer gradient contrast on light vs. dark system appearance | LOW | Test on both; adjust opacity/color of shimmer peak per color scheme |
+| Sentence-boundary chunking splits mid-thought | LOW | Use `NLTokenizer(unit: .sentence)` as upgrade path if needed |
+| `LoadingPopupText` growing too complex with 3 features | MEDIUM | Consider extracting to `LoadingPopupViewModel` (`@Observable @MainActor`) that encapsulates pivot + chunking logic, leaving `LoadingPopupText` as thin view |
 
 ---
 

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -181,18 +181,18 @@ TextChunker (new, in TextChunker.swift):
 `translationAction` in `LoadingPopupText` becomes:
 ```swift
 let chunks = TextChunker.chunks(from: requestContext.sourceText)
-var assembled: [String] = []
-for chunk in chunks {
-    let response = try await session.translate(chunk)
-    assembled.append(response.targetText)
+let requests = chunks.enumerated().map { idx, chunk in
+    TranslationSession.Request(sourceText: chunk, clientIdentifier: String(idx))
 }
-await onResult(requestID, sourceText, assembled.joined(separator: " "))
+let responses = try await session.translations(from: requests)
+let assembled = responses.map(\.targetText).joined(separator: " ")
+await onResult(requestID, sourceText, assembled)
 ```
 
-Sequential (not parallel) because:
-1. It is undocumented whether multiple concurrent `session.translate()` calls on the same `TranslationSession` are safe — Apple docs show single-call examples only (confidence: LOW that parallel is safe)
-2. Sequential preserves insertion order trivially
-3. Apple's on-device ML pipeline may internally batch — actual latency gain from parallelism is unclear
+Uses the batch API because:
+1. Single network/inference round-trip regardless of chunk count — avoids N× latency of sequential `translate()` calls
+2. Results are returned as `[Response]` in the same order as the input array — no `clientIdentifier` mapping needed
+3. Cleaner, shorter call site
 
 #### Integration with pivot (combined path)
 When both pivot and chunking apply (text > 200 chars AND unsupported language pair):

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,192 +1,298 @@
 # Feature Research
 
-**Domain:** macOS menu-bar selected-text translation utility (Japanese/English reading assistance)
-**Researched:** 2026-03-14
-**Confidence:** HIGH — domain is well-understood; competitors (DeepL for Mac, Bob, PopClip + translation plugins, Elytra) are established reference points
+**Domain:** macOS menu-bar translation app — v0.5.0 Translation Quality milestone
+**Researched:** 2026-04-06
+**Confidence:** HIGH for UX behavior and edge cases (derived from codebase analysis + Apple Translation framework constraints); MEDIUM for exact Apple Translation batch API surface (verified from framework usage patterns, not live docs)
+
+---
+
+## Context: What Already Exists
+
+These features build on top of a shipped v0.4.0 foundation. Key architectural anchors:
+
+- **`TranslationCoordinator.PopupState`**: `.hidden` → `.loading(requestID, sourceText)` → `.result` / `.error`
+- **`LoadingPopupText`**: SwiftUI view that owns `@State var translationConfiguration: TranslationSession.Configuration?` and fires `.translationTask(translationConfiguration, action:)` — the Apple Translation session lifecycle is view-scoped
+- **`PopupView`**: switches on `popupState`; `.loading` case renders `LoadingPopupText`; `.result`/`.error` render `PopupText`
+- **`PopupText`**: renders a scrollable text block inside `.regularMaterial` rounded rect; max 640×200 pt; `isMuted: true` shows `.secondary` color (current loading placeholder)
+- **`PopupController`**: tears down and recreates the SwiftUI hosting tree on each show — this cancels any in-flight `.translationTask`
+- **`TranslationErrorMapper`**: maps `TranslationError.unsupportedLanguagePairing`, `.unsupportedSourceLanguage`, `.unsupportedTargetLanguage` to the user-facing string "This language pair isn't supported."
+
+---
 
 ## Feature Landscape
 
-### Table Stakes (Users Expect These)
+### Table Stakes for v0.5.0 (Must Deliver)
 
-Features users assume exist. Missing these = product feels incomplete.
+The three features in scope. All are **required** — they define the milestone.
 
-| Feature | Why Expected | Complexity | Notes |
+| Feature | Why Required | Complexity | Notes |
 |---------|--------------|------------|-------|
-| System-wide selected-text capture | Core mechanic — must work in every app (Safari, PDF viewer, terminal, IDE) | MEDIUM | Requires a validated system-wide monitoring approach plus safe clipboard capture after the copy event. The exact permission model depends on the chosen monitoring API. |
-| Auto source-language detection | Users never want to specify "Japanese" — it's obvious from the characters | LOW | All major translation APIs (DeepL, OpenAI, Google) detect source automatically. Just don't expose source language selection in the UI. |
-| Configurable target language | Users translate into different languages; must be changeable | LOW | Single preference in a settings panel. Store in `UserDefaults`. |
-| Transient, non-focus-stealing popup | Must not break the reading app's focus — user is still in another window | MEDIUM | Use `NSPanel` with `.nonactivatingPanel` behavior, or a borderless `NSWindow` with `NSWindowLevel.floating`. Do NOT use a standard `NSWindow` that steals key focus. |
-| Keyboard dismissal (Escape) | macOS convention for all transient UI — popups dismissed by Escape | LOW | Monitor `keyDown` on the floating panel. Auto-dismiss on click-outside is also expected. |
-| Menu bar residence, no Dock icon | Fundamental to the "ambient tool" contract — this is a utility, not an app | LOW | `LSUIElement = YES` in Info.plist. `NSStatusItem` for menu bar icon. |
-| Launch at Login option | Menu bar utilities are expected to survive reboots without user intervention | LOW | Use `SMAppService.mainApp` (macOS 13+) or `LaunchAgent` plist. |
-| At least one high-quality translation provider | The translation must actually be good — poor MT quality is an instant uninstall | LOW-MEDIUM | Apple Translation is the chosen v1 backend for speed and native integration. External providers remain a future fallback if quality or language coverage becomes a problem. |
+| English pivot translation | Unsupported pairs (JP→DE, ZH→FR, etc.) currently show an error. This is a hard UX failure — the user gets nothing. Pivot is the fix. | MEDIUM | Two-session problem: needs two sequential `.translationTask` invocations; see Architecture section |
+| Shimmer/skeleton animation | Currently loading shows static muted source text — acceptable but unpolished. Shimmer signals "work in progress" more clearly and aligns with macOS skeleton loading conventions. | LOW | Pure SwiftUI animation added to `LoadingPopupText`; no state machine changes needed |
+| Chunked translation | Apple Translation may degrade on long inputs; long source text also fills the 200pt-height popup leaving no room for the result. Chunking improves both translation quality and display appropriateness. | MEDIUM | Requires text splitting logic + batch or sequential translation within a single session |
 
-### Differentiators (Competitive Advantage)
-
-Features that set the product apart. Not required, but valuable.
+### Differentiators
 
 | Feature | Value Proposition | Complexity | Notes |
 |---------|-------------------|------------|-------|
-| Double-Cmd+C as trigger | Zero new muscle memory — reuses the copy gesture everyone already performs; fastest possible activation path | MEDIUM | Detect two `Command+C` events within ~400ms threshold using the validated system-wide monitoring approach. Must NOT conflict with apps that legitimately use double-copy (e.g., some terminal emulators). Add a debounce. |
-| Source text as skeleton/loading placeholder | Preserves reading context while API call is in-flight; makes latency feel designed rather than broken; distinguishes from competitors who show blank-then-result | MEDIUM | Show original clipboard text styled as a muted/skeleton treatment on popup open. Replace with translated text when response arrives. Animated shimmer optional but polished. |
-| Speed-first architecture | The stated reason this product exists — DeepL for Mac is "too slow" | MEDIUM | Minimize: popup open latency (pre-warm the window), model-availability surprises, and render time (no heavy framework). Show popup immediately on trigger, don't wait for translation. |
-| Copy translation button | After reading the translation, user often wants to paste it somewhere | LOW | Single button or Cmd+C on the popup copies translated text. Clear visual affordance. |
-| Popup positioning near context | Appearing close to where the user was reading keeps their eye from traveling far | HIGH | Requires `AXUIElement` Accessibility API to get selection bounds — non-trivial. Fallback: fixed position (bottom-right of current screen). Flag for phase-specific research. |
-| Provider selection in settings | Power users want DeepL vs OpenAI vs Google choice based on content type | LOW-MEDIUM | Simple enum picker in settings if provider fallback is added later. Abstract translation behind a protocol so providers are interchangeable. |
-| Streaming translation display | For longer text, show tokens appearing progressively instead of a long blank wait | MEDIUM-HIGH | OpenAI and DeepL v3 support streaming. Requires async streaming parser and incremental UI updates. Reduces perceived latency for multi-sentence input significantly. |
+| Transparent pivot (no user action) | User copies JP text with DE target → gets German result with no error, no reconfiguration. Competitors that expose "via English" intermediate as an error are worse UX. | LOW (UX) | Pivot should be invisible; a subtle "(via English)" footnote is optional polish, not required |
+| Sentence-boundary chunking | Splitting at 。！？.!? and \n\n preserves translation coherence. Naive character-count splits produce fragments that degrade quality. | LOW (delta) | The split logic is the differentiator vs a naïve substr() approach |
+| Shimmer that preserves source text | Shimmer overlays the muted source text (not blank placeholder bars) — user can read context during wait. This is already the v0.4.0 philosophy; shimmer enhances rather than replaces it. | LOW | Key constraint: shimmer must not obscure the source text content |
 
-### Anti-Features (Commonly Requested, Often Problematic)
-
-Features that seem good but create problems.
+### Anti-Features (Do Not Build)
 
 | Feature | Why Requested | Why Problematic | Alternative |
 |---------|---------------|-----------------|-------------|
-| Translation history / log | "I want to see what I translated earlier" | Fundamentally changes the product from ambient to database. Privacy exposure (logging private documents). Clutters UI. Directly contradicts "glance and continue" intent. Out of scope per PROJECT.md. | Don't build it. If user needs history, they can paste into a notes app after translation. |
-| Manual text input box in popup | "What if I can't select text?" | Contradicts the entire UX philosophy. Adds UI weight to a popup that should be minimal. Invites "full app" scope creep. Different modality (compose vs translate) belongs in a different tool. | Power users can use a full translation app or website for edge cases. Keep Transy opinionated. |
-| OCR / screenshot translation | Competitive with apps like Bob — "can you translate text in images?" | Extremely high complexity (AVFoundation + Vision framework + layout detection). Different trigger model. Different UX. Would double the codebase scope for a secondary use case. | Scope to v2+ only if the core loop proves out. Bob already does this well. |
-| Multiple simultaneous provider results | "Show me DeepL and Google side by side" | Doubles API latency, doubles cost, makes popup 2× taller, dilutes trust in any single result. Adds provider comparison UX that breaks the "glance" pattern. | Keep Apple Translation as the default in v1. Allow provider fallback later if it proves necessary. |
-| Shortcut remapping UI | "I want to use Option+T instead of double-Cmd+C" | Shortcut conflict detection is hard. Custom key capture UI is fiddle-prone. Not needed for a personal tool. Premature generalization. | Hard-code double-Cmd+C for v1. Add remapping only if real user demand surfaces after launch. |
-| Pronunciation / furigana rendering | Useful for Japanese learners — "show me how to read this kanji" | Different product (reading assistant vs translator). Requires separate API or MeCab/ICU integration. Adds UI complexity. Translation is the core value. | Out of scope. Anki, Yomichan/Yomitan, or dedicated Japanese tools do this better. |
-| Notification Center alerts | "Notify me when translation is ready" | Users are staring at the selection they just copied — a notification is the wrong feedback channel and adds OS-level clutter. | The popup IS the notification. |
-| Auto-copy translated text to clipboard | "Automatically replace clipboard with translation" | Silently destroys the user's original copied text, which they may still need. Creates invisible state mutations. Confusing when pasting elsewhere yields unexpected text. | Provide an explicit "copy translation" button in the popup. User opts in. |
+| Show "Translating via English…" progress label | Transparency about pivot internals | Adds UI complexity; reveals implementation detail that users don't need; makes failure surface more visible without benefit | Silent pivot; show result; only surface error if both legs fail |
+| Parallel chunk translation with Task groups | "Faster if chunks run concurrently" | Apple Translation sessions are view-scoped resources managed by `.translationTask`; concurrent sessions require multiple view attachments and state coordination that dramatically increases complexity. Batch API (`session.translations(from:)`) achieves the same in one call with correct ordering. | Use batch API (`session.translations(from:)`) or sequential loop — same speed, far simpler |
+| Per-chunk error recovery | "If chunk 3 fails, retry just that chunk" | Adds retry state machine per chunk; complicates join logic; the failure modes are either the pair is unsupported (all chunks fail) or transient (retry the whole request). Per-chunk retry is over-engineering. | Fail the whole translation and let the user retry by re-copying |
+| Configurable chunk size in Settings | Power-user control over 200-char threshold | The 200-char default is based on the popup height constraint and framework sweet spot. Users don't think in "translation chunk sizes." | Hard-code 200 internally; tune based on real-world testing |
+| Animated progress for pivot phases | "Show leg 1 / leg 2 progress" | Pivot is fast (two on-device inferences); adding phase indicators introduces UI complexity that's visible only for ~300ms. | One shimmer, one result. Done. |
+
+---
+
+## Per-Feature UX Behavior and Edge Cases
+
+### Feature 1: English Pivot Translation
+
+#### Expected User-Facing Behavior
+
+```
+User copies: "今日はとても良い天気です" with target = German
+↓
+Popup opens immediately (loading state, shimmer)
+↓
+Behind the scenes: JP→DE attempt → TranslationError.unsupportedLanguagePairing
+↓
+Pivot leg 1: JP→EN → "The weather is very nice today."
+↓
+Pivot leg 2: EN→DE → "Das Wetter ist heute sehr schön."
+↓
+Popup shows: "Das Wetter ist heute sehr schön."
+```
+
+No error. No intermediate English result shown. Total latency ~2× single translation.
+
+#### Edge Cases
+
+| Scenario | Expected Behavior | Implementation Note |
+|----------|------------------|---------------------|
+| Target language IS English (source→EN) | Direct translation, no pivot attempt | Pivot only if target ≠ English AND direct fails with unsupportedLanguagePairing |
+| Source language is auto-detected as English | Direct EN→target translation works; pivot shouldn't trigger | Pivot is only triggered by `unsupportedLanguagePairing` error, not by source language identity |
+| Both source and target are English | Shouldn't occur in normal use; if it does, direct translation handles it (Apple passes it through or returns identity) | No pivot needed |
+| Pivot leg 1 (source→EN) fails | Show `TranslationErrorMapper` message for leg-1 error (language detection failure or unsupported source) | Don't attempt leg 2 |
+| Pivot leg 2 (EN→target) fails | Show error ("This language pair isn't supported.") — EN→target should always work if target is a supported language | Indicates target language itself is not supported; surface error |
+| User copies new text during pivot | Race guard (`requestID` check in `finishIfStillActive` / `failIfStillActive`) discards stale pivot results | Existing race guard in `PopupView` already handles this via `translationCoordinator.activeRequestID` check |
+| Source pair is supported directly (e.g., JP→EN) | No pivot — direct translation succeeds | Pivot is never attempted; the `unsupportedLanguagePairing` error is the gate |
+| Unsupported source language (e.g., obscure script Apple doesn't support) | Leg 1 fails; show "Couldn't detect the source language." or "This language pair isn't supported." as appropriate | `TranslationErrorMapper` handles this from leg-1 error |
+
+#### Architecture Constraint (CRITICAL)
+
+Apple's `TranslationSession` is **view-scoped** — created by the `.translationTask` modifier, not instantiable directly. Pivot requires two sessions with different configurations:
+- Leg 1: `source=nil` (auto-detect), `target=.english`
+- Leg 2: `source=.english`, `target=userTargetLanguage`
+
+**Implication:** `LoadingPopupText` needs a **second** `@State var pivotConfiguration: TranslationSession.Configuration?` and a **second** `.translationTask(pivotConfiguration, pivotAction:)` modifier. The two legs coordinate via `@State` — leg 1 stores its English result and sets `pivotConfiguration` to trigger leg 2.
+
+This is a **medium-complexity** view change, not a simple closure modification. The state machine inside `LoadingPopupText` grows from 1 configuration to 2.
+
+---
+
+### Feature 2: Shimmer/Skeleton Animation
+
+#### Expected User-Facing Behavior
+
+```
+User copies text
+↓
+Popup opens with source text visible (muted/secondary color, as today)
+↓
+Animated diagonal shimmer sweeps across the text continuously
+↓
+Translation arrives → shimmer stops → text swaps to translated result (primary color)
+```
+
+The shimmer is an overlay animation — the source text remains **readable** underneath. It is not blank placeholder bars. This is the defining constraint: Transy's loading state preserves reading context.
+
+#### UX Behavior Details
+
+- **Shimmer direction:** horizontal left-to-right sweep is standard; diagonal (left-to-right + slight upward) is subtler and more premium
+- **Shimmer speed:** ~1.5–2 seconds per cycle (too fast = anxiety, too slow = looks frozen)
+- **Shimmer opacity:** ~0.3–0.4 max alpha on the highlight. Subtle. Does not obscure text.
+- **Shimmer colors:** a `LinearGradient` from `.clear` → `white.opacity(0.35)` → `.clear` on the `mask` layer; adapts to light/dark mode without explicit color checks
+- **Animation repeat:** `.repeatForever(autoreverses: false)` — one-directional sweep, not back-and-forth
+- **Shimmer starts:** immediately when `LoadingPopupText` appears (`.onAppear` or `initial: true` on the `onChange`)
+- **Shimmer stops:** naturally when the `.loading` state transitions to `.result` or `.error` — the `LoadingPopupText` view is replaced entirely, so no explicit "stop animation" needed
+
+#### Edge Cases
+
+| Scenario | Expected Behavior | Implementation Note |
+|----------|------------------|---------------------|
+| Translation completes in <100ms (very short text) | Shimmer may not complete a full cycle; result replaces it immediately | Fine — no user-visible problem; `.id(requestID)` reset resets animation state |
+| Window resizes during shimmer (content height changes as font renders) | Shimmer must not glitch or restart during height animation | Apply shimmer as a `mask` overlay on `PopupText` — it's size-independent |
+| Dark mode | Shimmer gradient must remain visible against dark `.regularMaterial` | Use `Color.white.opacity(0.3)` in the gradient — white shimmer works in both modes |
+| Rapid re-trigger (user copies again before first result) | `PopupController` tears down the hosting view tree; new `LoadingPopupText` gets fresh shimmer | Handled by existing architecture |
+| Long pivot translation (shimmer runs ~2× duration) | Shimmer must continue through both pivot legs | Shimmer is tied to `LoadingPopupText` lifetime, not to a specific `.translationTask` invocation |
+| Reduced Motion accessibility setting | Should respect `@Environment(\.accessibilityReduceMotion)` — no sweep animation; keep the muted text only | Check `accessibilityReduceMotion`; skip shimmer animation if true |
+
+#### Implementation Pattern
+
+```swift
+// Conceptual — shimmer modifier applied to PopupText inside LoadingPopupText
+PopupText(text: requestContext.sourceText, isMuted: true)
+    .shimmer(isActive: true)  // custom ViewModifier
+```
+
+The shimmer `ViewModifier` applies a `LinearGradient` mask with an `@State private var offset: CGFloat` animated from `-1.0` to `2.0` (normalized coordinates). Uses `withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false))` on appear.
+
+---
+
+### Feature 3: Chunked Translation
+
+#### Expected User-Facing Behavior
+
+```
+User copies long text (e.g., 450-char paragraph)
+↓
+Popup opens with source text visible and shimmer running (same loading state as always)
+↓
+Behind the scenes: text split into 3 chunks at sentence boundaries
+↓
+All 3 chunks translated (batch or sequential)
+↓
+Results joined with original separator (\n or space)
+↓
+Popup shows full translated paragraph (scrollable if > 200pt height)
+```
+
+Chunking is **transparent** to the user. They see one result, not three. The only visible difference is (potentially) slightly longer loading time for very long texts, compensated by the shimmer.
+
+#### Splitting Strategy (Priority Order)
+
+1. **Paragraph breaks** (`\n\n`): strongest boundary — always split here
+2. **Sentence-ending punctuation + space** (`.` `!` `?` `。` `！` `？` followed by whitespace or end): natural sentence boundary
+3. **Line breaks** (`\n`): weaker boundary — use if chunks are still >200 chars after paragraph splits
+4. **Whitespace** (as last resort): split at word boundary nearest to 200-char mark
+5. **Hard cut** (absolute last resort for single-token dense text like URLs or code): split at char 200
+
+#### Chunk Size Policy
+
+- **Target chunk size:** ≤200 chars (matches popup display height and framework sweet spot)
+- **Minimum chunk size:** ~10 chars — chunks shorter than this should be **merged** with the adjacent chunk to avoid fragmenting punctuation or single words
+- **Maximum chunk size:** 250 chars with some tolerance (don't split "Paris." from the surrounding sentence just to hit exactly 200)
+- **Empty chunks:** filtered out before translation (double spaces, blank lines between paragraphs)
+
+#### Join Strategy
+
+- Chunks joined with the **same separator they were split on**: paragraph breaks join with `\n\n`, sentence breaks join with ` `, line breaks join with `\n`
+- **Order preservation is mandatory** — use batch API (`session.translations(from:)`) or a sequential indexed loop, never an unordered `TaskGroup`
+- Do not add extra whitespace or punctuation between joined chunks
+
+#### Edge Cases
+
+| Scenario | Expected Behavior | Implementation Note |
+|----------|------------------|---------------------|
+| Text ≤200 chars | No chunking — single `session.translate()` call | Guard at start of translation action |
+| Text with no sentence boundaries (wall of text) | Split at whitespace nearest 200 chars | Fallback splitting strategy |
+| CJK text without spaces | CJK sentence-end markers (。！？) are the primary split points | CJK doesn't have word spaces; can split immediately after 。！？ |
+| Mixed CJK + Latin text | Both punctuation sets apply — split at whichever comes first after ~150 chars | `。` and `.` both valid sentence ends |
+| Single "word" >200 chars (URL, code) | Hard split at char 200 as last resort | Result quality may be poor but at least something is returned |
+| Chunk translation fails mid-way | Fail the whole translation (surface error to user) | Use `throws`; first error propagates out of the batch |
+| Chunk count creates >10 chunks (very long text) | No upper bound on chunks — translate all; popup scrolls | No artificial limit; Apple Translation handles arrays |
+| Pivot + chunking needed | Pivot applies **per-chunk**: each chunk goes through source→EN→target when pair is unsupported | See interaction notes below |
+| Leading/trailing whitespace on a chunk | Strip each chunk before translation; restore separator at join | `trimmingCharacters(in: .whitespacesAndNewlines)` per chunk |
+
+#### Pivot × Chunking Interaction
+
+When both pivot and chunking are active (text >200 chars AND pair is unsupported):
+
+**Recommended approach:** detect pair support once, then apply the strategy to all chunks.
+
+```
+Option A — Error-triggered per-chunk pivot:
+  Try direct translation of chunk[0]
+  → unsupportedLanguagePairing error → switch ALL remaining chunks to pivot mode
+  → translate chunk[0] via pivot; all subsequent chunks via pivot
+  Pros: reuses existing error-catch mechanism
+  Cons: chunk[0] is wasted (gets an error then re-translated), adds latency for first chunk
+
+Option B — Proactive pair check before chunking:
+  Call LanguageAvailability().status(from: source, to: target) once before chunking
+  → if unsupported → use pivot strategy for all chunks from the start
+  Cons: Proactive check was removed in v0.4.0 to avoid double ML inference;
+        re-adding it for long text only is an acceptable compromise
+
+Option C — Blind pivot for all chunks:
+  Always chunk AND always pivot (two-step translation for every chunk)
+  Pros: simple, no conditional logic
+  Cons: doubles latency for ALL translated text, even supported pairs
+  → Rejected
+```
+
+**Recommendation:** Option A — detect failure on first chunk, pivot remaining chunks. The first-chunk re-translation overhead is one extra inference (~150ms), which is acceptable given the alternative complexity of re-adding a proactive check.
+
+---
 
 ## Feature Dependencies
 
 ```
-[Double-Cmd+C Trigger]
-    └──requires──> [Validated trigger monitor / Clipboard Monitoring]
-                       └──requires──> [Required privacy permission(s) for chosen monitoring API]
+[Shimmer Animation]
+    └──requires──> [LoadingPopupText] (existing)
+    └──requires──> [PopupText with isMuted=true] (existing)
+    └──enhances──> [Chunked Translation] (shimmer runs during longer chunk wait)
+    └──enhances──> [Pivot Translation] (shimmer runs during 2-leg wait)
 
-[Translation Popup]
-    └──requires──> [NSPanel / NSWindow (non-activating)]
-    └──requires──> [Apple Translation integration]
-                       └──requires──> [Model availability guidance in settings/runtime]
+[Pivot Translation]
+    └──requires──> [LoadingPopupText with 2-config state machine] (new)
+    └──requires──> [TranslationErrorMapper.unsupportedLanguagePair detection] (existing)
+    └──interacts──> [Chunked Translation] (pivot strategy must propagate to all chunks)
 
-[Source Text as Skeleton Placeholder]
-    └──requires──> [Translation Popup]
-    └──requires──> [Clipboard text read before API call]
-    └──enhances──> [Speed perception — popup opens immediately]
-
-[Target Language Config]
-    └──requires──> [Settings Window]
-    └──requires──> [UserDefaults persistence]
-
-[Copy Translation Button]
-    └──requires──> [Translation Popup]
-    └──requires──> [NSPasteboard write]
-
-[Provider Selection]
-    └──requires──> [Settings Window]
-    └──requires──> [Translation protocol abstraction]
-
-[Streaming Translation Display]
-    └──requires──> [Translation Popup]
-    └──requires──> [Streaming API support from chosen provider]
-    └──enhances──> [Source text placeholder — transition from skeleton to streaming text]
-
-[Popup Positioning Near Selection]
-    └──requires──> [AXUIElement Accessibility API]  ← HIGH complexity, research flag
-    └──conflicts──> [Fixed popup position] (use one or the other)
-
-[Launch at Login]
-    └──requires──> [SMAppService (macOS 13+) or LaunchAgent]
+[Chunked Translation]
+    └──requires──> [Text splitting utility] (new)
+    └──requires──> [Translation.framework batch API: session.translations(from:)] (verify availability)
+    └──interacts──> [Pivot Translation] (chunk error triggers pivot mode for remaining chunks)
+    └──enhances──> [Shimmer Animation] (longer loading makes shimmer more visible and valuable)
 ```
 
 ### Dependency Notes
 
-- **Double-Cmd+C trigger requires clear permission handling:** the exact permission path depends on the chosen monitoring API, and Phase 1 must validate and document it clearly for users.
-- **Source-as-skeleton requires popup-first architecture:** The popup must open synchronously on trigger (showing original text), with translation filling in asynchronously. If the popup blocks on API response, the skeleton feature is impossible.
-- **Streaming enhances skeleton:** The natural progression is: trigger → popup opens with source text skeleton → translation tokens stream in replacing the skeleton. Streaming is an enhancement; without it, skeleton shows until full result arrives.
-- **Provider selection requires protocol abstraction:** If translation is hard-coded to one provider, adding selection later requires refactoring. Define a `TranslationProvider` protocol from day one even if only one provider is implemented.
-- **Popup positioning conflicts with fixed position:** Decide once. AXUIElement positioning is high-effort and has edge cases (fullscreen apps, multiple monitors, split view). Fixed bottom-right fallback is predictable and fine for v1.
+- **Shimmer is independent**: it's a pure visual change to `LoadingPopupText`; it can be built and shipped without pivot or chunking being complete. Build shimmer first — it makes testing of the other two features more pleasant.
+- **Pivot requires view state machine extension**: `LoadingPopupText` must grow from one `@State var translationConfiguration` to two. This is a non-trivial change. Requires care around the race guard (both legs must share the same `requestID` and be gated by `activeRequestID`).
+- **Chunking is largely contained in the translation action closure**: the `translationAction` static method can be extended to split, batch-translate, and join without changing `PopupView`, `TranslationCoordinator`, or `PopupController`.
+- **Pivot × Chunking interaction must be designed explicitly**: if chunking is implemented first, the pivot feature needs to know whether it's operating on chunked mode. Design the translation action to support both modes composably before implementing either fully.
 
-## MVP Definition
+---
 
-### Launch With (v1)
+## Phase Ordering Recommendation
 
-Minimum viable product — what's needed to validate the concept.
+**Phase 1 — Shimmer animation** (independent, low risk, improves dev feedback loop for subsequent phases)
 
-- [ ] **Double-Cmd+C trigger via a validated system-wide monitoring approach** — without the trigger, there is no product
-- [ ] **Privacy-permission onboarding on first launch** — must clearly guide the user through the permissions required by the chosen monitoring approach
-- [ ] **Non-activating floating popup** — must not steal focus from the reading app
-- [ ] **Source text displayed as loading placeholder** — core UX differentiator; establishes the "designed latency" experience
-- [ ] **Translation result via Apple Translation framework** — on-device translation is the chosen v1 backend for speed, privacy, and native integration
-- [ ] **Auto source-language detection** — no manual source language picker
-- [ ] **Target language selection in settings window** — project's stated requirement
-- [ ] **Escape / click-outside dismissal** — macOS convention; feels broken without this
-- [ ] **Menu bar icon, no Dock presence** — `LSUIElement`, `NSStatusItem`
+**Phase 2 — Chunked translation** (self-contained in translation action; tests the batch API; no view state machine changes)
 
-### Add After Validation (v1.x)
+**Phase 3 — Pivot translation** (highest complexity due to two-session view architecture; benefits from chunked being complete so pivot×chunking interaction is implemented together)
 
-Features to add once core is working.
+---
 
-- [ ] **Copy translation button in popup** — trigger: users will immediately want to paste the translation; add when core loop is validated
-- [ ] **External-provider fallback / selection** — trigger: if Apple Translation quality or language coverage is insufficient for some use cases
-- [ ] **Launch at Login toggle** — trigger: if the app becomes part of the user's everyday workflow and should survive restarts
-- [ ] **Double-Cmd+C timing threshold setting** — trigger: user complaints about false triggers or missed triggers
+## Prioritization Matrix
 
-### Future Consideration (v2+)
+| Feature | User Value | Implementation Cost | Priority | Build Order |
+|---------|------------|---------------------|----------|-------------|
+| Pivot Translation | HIGH (unblocks JP→DE, ZH→FR, etc. — previously errors) | MEDIUM (two-session state machine) | P1 | 3rd |
+| Shimmer Animation | MEDIUM (polish; existing loading UX is acceptable) | LOW (ViewModifier + animation) | P1 | 1st |
+| Chunked Translation | MEDIUM (quality/perf for long text; most users copy short passages) | MEDIUM (splitting + batch API) | P1 | 2nd |
 
-Features to defer until product-market fit is established.
+All three are P1 for v0.5.0 — they define the milestone. Build order is based on complexity and dependency chain, not priority.
 
-- [ ] **Popup positioning near selection (AXUIElement)** — high complexity, marginal gain for v1; fixed position is acceptable
-- [ ] **Custom trigger shortcut** — defer until there's actual demand; personal tool doesn't need this
-- [ ] **OCR / screenshot translation** — different modality, much higher complexity; only if core loop proves broadly useful
-
-## Feature Prioritization Matrix
-
-| Feature | User Value | Implementation Cost | Priority |
-|---------|------------|---------------------|----------|
-| Double-Cmd+C trigger | HIGH | MEDIUM | P1 |
-| Non-activating popup | HIGH | MEDIUM | P1 |
-| Source text as skeleton placeholder | HIGH | LOW | P1 |
-| Apple Translation framework translation | HIGH | LOW | P1 |
-| Auto language detection | HIGH | LOW | P1 |
-| Target language config (settings) | HIGH | LOW | P1 |
-| Escape / click-outside dismiss | HIGH | LOW | P1 |
-| Menu bar only / no Dock | HIGH | LOW | P1 |
-| Launch at Login | MEDIUM | LOW | P2 |
-| Privacy-permission onboarding | HIGH | LOW | P1 — required for trigger to work |
-| Copy translation button | MEDIUM | LOW | P2 |
-| Provider selection | MEDIUM | MEDIUM | P2 |
-| Popup positioning near selection | MEDIUM | HIGH | P3 |
-| Custom trigger shortcut | LOW | HIGH | P3 |
-| OCR translation | LOW | HIGH | P3 |
-
-**Priority key:**
-- P1: Must have for launch
-- P2: Should have, add when possible
-- P3: Nice to have, future consideration
-
-## Competitor Feature Analysis
-
-| Feature | DeepL for Mac | Bob (macOS) | PopClip + plugin | Transy approach |
-|---------|---------------|-------------|------------------|-----------------|
-| Trigger mechanism | Menu bar → "Translate Clipboard" or global hotkey | Global hotkey (configurable) | Appears on any text selection via OS text selection popup | Double-Cmd+C — reuses copy gesture, zero config |
-| Popup style | Full DeepL app window (heavy, takes focus) | Floating panel, native-ish | Compact horizontal bar near selection | Minimal floating panel, non-activating |
-| Source-as-placeholder | No (blank while loading) | No (blank or spinner) | No | Yes — core differentiator |
-| Speed to result | Slow (app launch + API) | Fast (pre-warmed window) | Fast (pre-warmed PopClip) | Target: fast (pre-warm panel + immediate open) |
-| Auto language detect | Yes | Yes | Yes (provider-dependent) | Yes |
-| Translation providers | DeepL only | DeepL, OpenAI, Google, many more | Provider-dependent extension | Apple Translation as default; protocol for extensibility |
-| macOS-native feel | Medium (Electron-adjacent) | Medium-High | High (OS-level) | Target: High (pure SwiftUI/AppKit) |
-| OCR translation | No | Yes | No | No — out of scope |
-| Translation history | Yes | Yes | No | No — out of scope |
-| Dock icon | No (menu bar) | No (menu bar) | N/A (PopClip extension) | No — LSUIElement |
-| Shortcut customization | Yes | Yes | Via PopClip settings | No for v1 |
-| Free tier | Yes (limited) | Freemium | Paid (PopClip itself) | Built-in on-device translation with system-managed models |
+---
 
 ## Sources
 
-- DeepL for Mac: direct product analysis — https://www.deepl.com/en/macos-app
-- Bob (macOS translation utility): https://bobtranslate.com — direct product analysis; closest functional competitor to Transy
-- PopClip with translation extensions: https://www.popclip.app — selected-text popup pattern reference
-- macOS Human Interface Guidelines — transient panels, menu bar extras, focus behavior
-- NSEvent / event-monitoring documentation (Apple Developer): candidate APIs for global key event observation
-- SMAppService documentation (Apple Developer, macOS 13+): modern launch-at-login API
-- DeepL API documentation: https://developers.deepl.com/docs — language detection, streaming support
-- OpenAI API (GPT-4o): streaming translation capability reference
+- Codebase analysis: `PopupView.swift`, `TranslationCoordinator.swift`, `PopupController.swift`, `TranslationErrorMapper.swift` — verified 2026-04-06
+- Apple Translation framework architecture: `.translationTask` modifier, `TranslationSession.Configuration`, session lifecycle — derived from existing codebase patterns
+- Apple Translation framework supported languages: `LanguageAvailability().supportedLanguages` (runtime), referenced via `SupportedLanguageOption.swift`
+- macOS HIG — Reduced Motion accessibility guideline for animation
+- SwiftUI shimmer pattern: standard gradient-mask animation approach (widely adopted in iOS/macOS skeleton loading UIs)
 
 ---
-*Feature research for: macOS selected-text translation utility (Japanese/English reading assistant)*
-*Researched: 2026-03-14*
-*Reconciled after backend selection: Apple Translation framework*
+*Feature research for: Transy v0.5.0 — pivot translation, shimmer animation, chunked translation*
+*Researched: 2026-04-06*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,153 +1,319 @@
 # Pitfalls Research
 
-**Domain:** macOS menu bar selected-text translator (SwiftUI/AppKit, clipboard-based trigger, on-device translation)
-**Researched:** 2026-03-14
+**Domain:** Adding pivot translation, shimmer animation, and chunked translation to Transy v0.5.0 (macOS 15+, SwiftUI/AppKit, Apple Translation framework, Swift 6 strict concurrency)
+**Researched:** 2026-04-04
 **Confidence:** HIGH
 
 ---
 
 ## Critical Pitfalls
 
-### Pitfall 1: Reading the Clipboard Too Early
+### Pitfall 1: Pivot — `unsupportedLanguagePairing` swallowed by `TranslationErrorMapper` before pivot can retry
 
 **What goes wrong:**
-The trigger fires before the source app has finished writing the copied selection to `NSPasteboard`, so Transy reads stale or empty content.
+The current `translationAction` catch block calls `TranslationErrorMapper.message(for: error)` → `onError(...)` for all non-cancellation errors. `TranslationErrorMapper` already maps `TranslationError.unsupportedLanguagePairing` to the string `"This language pair isn't supported."` and the error path terminates. Pivot never fires because the signal is consumed and converted to a display string before any retry logic can see it.
+
+**Why it happens:**
+The catch block was designed to present errors to users. Pivot requires intercepting a specific error and retrying rather than surfacing it. The two concerns (display vs. retry) live in the same catch site today.
 
 **How to avoid:**
-- Validate a small delayed read in Phase 2 (for example, ~50–100 ms)
-- Check pasteboard change state before consuming the content
-- Fail visibly rather than translating the wrong string
+Split the catch block in `translationAction`. Catch `TranslationError.unsupportedLanguagePairing` (and `.unsupportedSourceLanguage` / `.unsupportedTargetLanguage`) first, before the generic handler, and invoke the pivot path from there. Only fall through to `onError` if pivot itself fails or is not applicable.
 
-**Phase to address:** Trigger & Popup
+```swift
+} catch TranslationError.unsupportedLanguagePairing,
+        TranslationError.unsupportedSourceLanguage,
+        TranslationError.unsupportedTargetLanguage {
+    // trigger pivot — do NOT call onError here
+} catch is CancellationError {
+    return
+} catch {
+    await onError(...)
+}
+```
+
+**Warning signs:**
+User copies JP text when target is DE (or any other unsupported direct pair) and sees `"This language pair isn't supported."` instead of a translated result.
+
+**Phase to address:** Pivot Translation (Phase 1 of v0.5.0)
 
 ---
 
-### Pitfall 2: Popup Steals Focus from the Source App
+### Pitfall 2: Pivot — Two translation legs cannot share one `.translationTask()` session
 
 **What goes wrong:**
-A normal window activates Transy and breaks the user's reading flow.
+The `TranslationSession` provided to the `.translationTask()` action callback is scoped to that callback's execution. It cannot be stored, passed out of the closure, or used after the closure returns. A developer implementing pivot naively may try to translate source→EN and then EN→target using the same session by calling `session.translate()` twice with different content — the second call uses a session configured for the wrong language pair (or auto-detection that may misfire on short English intermediates).
+
+**Why it happens:**
+`TranslationSession.Configuration` encodes the source/target language pair. One session = one pair. Reusing the same session for a different pair silently uses the wrong model.
 
 **How to avoid:**
-- Use `NSPanel` with non-activating behavior
-- Never design the popup around `WindowGroup` semantics
-- Verify Escape / click-outside dismissal without making Transy the foreground app
+Introduce a second `@State private var pivotConfiguration: TranslationSession.Configuration?` in `LoadingPopupText` and a second `.translationTask(pivotConfiguration, action:)` modifier. The second modifier activates only when pivot is needed (i.e., pivot configuration is non-nil). The second leg's configuration must use `source: Locale.Language(identifier: "en")` — explicitly, not `nil`. With `source: nil` (auto-detect), short or ambiguous intermediate English text may be misidentified, causing the second leg to fail silently.
 
-**Phase to address:** Trigger & Popup
+**Warning signs:**
+JP→EN leg succeeds (intermediate English text exists) but EN→DE leg fails with a language detection error, or the DE result is actually EN text passed through unchanged.
+
+**Phase to address:** Pivot Translation (Phase 1 of v0.5.0)
 
 ---
 
-### Pitfall 3: Clipboard Contents Are Not Restored
+### Pitfall 3: Shimmer — animated size change triggers 60fps `repositionPanel()` loop
 
 **What goes wrong:**
-The double-copy gesture overwrites the user's previous clipboard contents and leaves them lost after translation.
+`PopupController.show()` attaches a `NotificationCenter` observer for `NSWindow.didResizeNotification` that calls `repositionPanel()` → `panel.setFrameOrigin()`. Any shimmer implementation that alters the view's intrinsic content size on each animation frame (e.g., an animated overlay that slightly changes padding, or a skeleton layout that differs from the source-text `PopupText` dimensions) fires `didResizeNotification` at 60fps. `repositionPanel()` calls `panel.setFrameOrigin()` on every frame, causing the panel to visibly stutter or drift at animation frequency.
+
+**Why it happens:**
+The resize observer was designed for discrete content swaps (source text → translation result). Continuous animation was not a design concern when that observer was written.
 
 **How to avoid:**
-- Snapshot the previous clipboard contents before capture
-- Restore them after the source text has been safely read
-- Treat clipboard preservation as a correctness requirement, not polish
+Shimmer must be a pure cosmetic overlay that never changes the view's frame size. Implement shimmer as an `.overlay` of a clipped `LinearGradient` with an animated `@State var phase: CGFloat` applied via `.mask` or `.blendMode`. The underlying `PopupText(text: sourceText, isMuted: true)` must remain the layout-governing view — same size, same padding. Verify in the Xcode view debugger that the `NSPanel` frame does not change during shimmer animation.
 
-**Phase to address:** Trigger & Popup
+**Warning signs:**
+Panel moves slightly left/right (or up/down) during translation loading. Opening `NSWindow.didResizeNotification` observer count in Instruments shows 60 calls/sec while the popup is in loading state.
+
+**Phase to address:** Shimmer Animation (Phase 2 of v0.5.0)
 
 ---
 
-### Pitfall 4: Permission Requirements Are Assumed Too Early
+### Pitfall 4: Chunked — using sequential `session.translate()` calls instead of the batch API
 
 **What goes wrong:**
-The project hard-codes a single permission or capability story before validating the actual monitoring API that will be used in Phase 1.
+Implementing chunked translation as a `for chunk in chunks { let r = try await session.translate(chunk) }` loop multiplies latency: N chunks × single-call latency = N× slowdown compared to the current single `translate()` call. For a 600-char text split into 3 chunks, the translation is now 3× slower, not faster.
+
+**Why it happens:**
+`session.translate(_ string: String)` is the familiar API from existing code. The batch API (`session.translations(from: [TranslationSession.Request])`) requires learning a different call signature and response stream, so developers default to what they know.
 
 **How to avoid:**
-- Treat permission behavior as an early validation task, not a solved assumption
-- Document the exact monitoring API and required user-facing guidance once validated
-- Keep roadmap language generic until the Phase 1 spike confirms the implementation path
+Use `TranslationSession.translations(from: [TranslationSession.Request])` which returns an `AsyncThrowingStream<TranslationSession.Response, Error>`. Assign a unique `clientIdentifier` to each `TranslationSession.Request` (e.g., chunk index as string). Collect responses from the stream into a dictionary keyed by `clientIdentifier`, then join in index order after the stream closes. Do not assume stream emission order equals input order — always use `clientIdentifier` to reconstruct ordering.
 
-**Phase to address:** App Shell / Trigger & Popup
+**Warning signs:**
+Chunked translation of a 600-char text is measurably slower than the v0.4.0 single-call translation of the same text.
+
+**Phase to address:** Chunked Translation (Phase 3 of v0.5.0)
 
 ---
 
-### Pitfall 5: Model Availability Is Treated as an Edge Case
+### Pitfall 5: Chunked — `NLTokenizer` used in `nonisolated` context violates Swift 6 concurrency
 
 **What goes wrong:**
-Apple Translation may require system-managed model downloads for the chosen language pair. If the app assumes the model always exists, translation fails with a confusing experience.
+The current `translationAction` is declared `nonisolated private static func`. `NLTokenizer` (NaturalLanguage framework) is an Objective-C class that does not conform to `Sendable`. Instantiating or calling it within the `nonisolated` async context of `translationAction` will produce a Swift 6 strict-concurrency error: the tokenizer must be used in a consistent isolation domain.
+
+**Why it happens:**
+Text chunking feels like a natural extension of `translationAction` since that's where text processing already happens. But `NLTokenizer` carries isolation requirements that `nonisolated` can't satisfy.
 
 **How to avoid:**
-- Check model/language availability before or during translation requests
-- Show clear guidance when a required model is missing
-- Connect settings UI and runtime error handling to the same availability story
+Perform text chunking outside of `translationAction`, synchronously on the `@MainActor`, before the session callback fires. The chunk array (an array of `String`, which is `Sendable`) can then be captured in the `translationAction` closure safely. Alternatively, wrap `NLTokenizer` usage in `await MainActor.run { }` inside the nonisolated context — but extracting it beforehand is cleaner and avoids an unnecessary hop back to main.
 
-**Phase to address:** Translation Loop / Settings
+```swift
+// In LoadingPopupText (already @MainActor via SwiftUI view body):
+let chunks = TextChunker.chunks(from: requestContext.sourceText) // runs on MainActor
+// Pass chunks array into the translationAction closure capture
+```
+
+**Warning signs:**
+Swift 6 compiler errors like `"Sending 'tokenizer' risks causing data races"` or `"Capture of non-Sendable type 'NLTokenizer'"` when adding chunking logic.
+
+**Phase to address:** Chunked Translation (Phase 3 of v0.5.0)
 
 ---
 
-### Pitfall 6: Translation Results Arrive Out of Order
+### Pitfall 6: Pivot mid-flight cancellation surfaces intermediate English text
 
 **What goes wrong:**
-The user triggers two translations quickly and an older request overwrites a newer one.
+During pivot, leg 1 (source→EN) completes and returns intermediate English text. Leg 2 (EN→target) begins. If the user dismisses the panel mid-pivot (Escape or outside click), `panel.contentView = nil` destroys the hosted SwiftUI tree, cancelling the `.translationTask()`. The `CancellationError` thrown in leg 2's callback is caught and `return`s cleanly. However, if pivot is implemented by calling `onResult` at the end of leg 1 (before leg 2) with the English text as a "partial result", the user sees raw English output instead of a clean dismiss.
+
+**Why it happens:**
+During development, calling `onResult` after leg 1 for debugging purposes. If that call is not removed, it becomes a real user-facing bug.
 
 **How to avoid:**
-- Use cancellation or request tokens in the coordinator
-- Only apply results if they still match the latest request
-- Keep popup state transitions centralized
+Never call `onResult` between pivot legs. The `requestID` guard in `finishIfStillActive` would catch some cases, but not all (if the panel hasn't been dismissed yet when leg 1 completes). The pivot flow must call `onResult` only once: after leg 2 produces the final translated text.
 
-**Phase to address:** Translation Loop
+**Warning signs:**
+When debugging pivot, the popup briefly shows English text before showing the final translated text (flash of intermediate content).
+
+**Phase to address:** Pivot Translation (Phase 1 of v0.5.0)
 
 ---
 
 ## Moderate Pitfalls
 
-### Pitfall 7: Double-Press Window Feels Wrong
+### Pitfall 7: Pivot — race between `unsupportedLanguagePairing` detection and a new clipboard event
 
 **What goes wrong:**
-If the double-press threshold is too short, the gesture never triggers. If too long, normal copy workflows feel hijacked.
+Leg 1 of pivot throws `unsupportedLanguagePairing`, the catch block detects it, and pivot leg 2 setup begins (setting `pivotConfiguration`). In this window, a new clipboard event fires: `translationCoordinator.begin()` issues a new `requestID`. When pivot leg 2 eventually completes, its `finishIfStillActive` guard correctly rejects the stale result (the stored `requestContext.requestID` is the old one). **However**, if the pivot leg 2 `.translationTask()` view is still alive (the new `requestID` uses `.id(newRequestID)` which creates a new `LoadingPopupText` instance), the old view's pivot session may still be running concurrently against the new request's session.
 
 **How to avoid:**
-- Start with a reasonable default
-- Validate with real usage on a real keyboard
-- Defer user configurability if needed, but design for it
+`.id(requestID)` on `LoadingPopupText` in `PopupView.body` already causes SwiftUI to destroy and recreate the view on each new request. This tears down both `.translationTask()` modifiers for the old request (including any mid-flight pivot session). Ensure pivot state (`@State var pivotConfiguration`) lives inside `LoadingPopupText` (not in a parent), so it's destroyed with the view identity change.
 
-### Pitfall 8: Popup Appears Off-Screen or Feels Detached
-
-**What goes wrong:**
-A fixed popup position may feel unnatural, and an unconstrained position may clip on multi-monitor setups or around the notch.
-
-**How to avoid:**
-- Clamp to visible screen bounds
-- Validate whether fixed positioning is acceptable for v1
-- Defer selection-relative positioning unless it becomes necessary
-
-### Pitfall 9: LSUIElement / Activation Policy Is Misconfigured
-
-**What goes wrong:**
-The app unexpectedly shows a Dock icon or behaves like a regular app window because menu bar utility settings were configured in the wrong place.
-
-**How to avoid:**
-- Set `LSUIElement` in `Info.plist`
-- Test settings-window opening behavior specifically
-- Verify the app does not appear in Cmd+Tab if that is the intended utility behavior
+**Phase to address:** Pivot Translation (Phase 1 of v0.5.0)
 
 ---
 
-## Phase Mapping Summary
+### Pitfall 8: Chunked — empty or whitespace-only chunks passed to `translate()`
 
-| Pitfall | Phase |
-|---------|-------|
-| Clipboard timing | Trigger & Popup |
-| Focus-stealing popup | Trigger & Popup |
-| Clipboard restoration | Trigger & Popup |
-| Permission ambiguity | App Shell / Trigger & Popup |
-| Model availability | Translation Loop / Settings |
-| Stale translation results | Translation Loop |
-| Double-press threshold | Trigger & Popup / Settings |
-| Popup placement | Trigger & Popup / Settings |
-| LSUIElement / activation policy | App Shell |
+**What goes wrong:**
+`NLTokenizer` with `.sentence` unit can emit ranges that produce empty strings or whitespace-only strings (e.g., between consecutive newlines, trailing whitespace after a sentence end). Passing `""` to `session.translate()` may return an empty response, throw an error, or return the empty string unchanged — but all three outcomes corrupt the joined result if not filtered before submission.
+
+**How to avoid:**
+Filter chunks with `chunk.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` before building `[TranslationSession.Request]`. Track the original positions of non-empty chunks to correctly reconstruct the final joined string (preserve spacing between chunks from the original text, do not re-derive from translated output).
+
+**Phase to address:** Chunked Translation (Phase 3 of v0.5.0)
+
+---
+
+### Pitfall 9: Shimmer — animation does not start because `withAnimation` fires before panel is visible
+
+**What goes wrong:**
+If the shimmer's `withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) { phase = 1.0 }` is triggered in a `.task {}` modifier, it may fire before the panel has completed its 0.15s `alphaValue` fade-in. On macOS, SwiftUI animations inside `NSHostingView` that start before the hosting view is in a visible window may be skipped or have their initial frame computed wrong, resulting in a shimmer that appears static or jumps to the end state.
+
+**How to avoid:**
+Start the shimmer animation in `.onAppear` (not `.task`, not the view initializer). `.onAppear` fires after SwiftUI has committed the view to the display tree, which on macOS corresponds to the hosting view being installed in the panel — after `panel.orderFrontRegardless()`.
+
+**Phase to address:** Shimmer Animation (Phase 2 of v0.5.0)
+
+---
+
+### Pitfall 10: Shimmer — `accessibilityReduceMotion` ignored
+
+**What goes wrong:**
+macOS System Settings → Accessibility → Display → Reduce Motion signals that the user does not want animated effects. SwiftUI exposes `@Environment(\.accessibilityReduceMotion)`. If shimmer ignores this, users who opted out of motion see a continuously pulsing effect — the opposite of their stated preference.
+
+**How to avoid:**
+Read `@Environment(\.accessibilityReduceMotion)` in the shimmer view. When `true`, substitute a static low-opacity treatment (e.g., constant `opacity(0.4)`) instead of the moving gradient. The substitution can be a simple conditional — no separate view needed.
+
+**Phase to address:** Shimmer Animation (Phase 2 of v0.5.0)
+
+---
+
+### Pitfall 11: Chunked — missing short-text bypass makes common case slower
+
+**What goes wrong:**
+`NLTokenizer` initialization, language hint configuration, and sentence enumeration add overhead. For the common case of selected text under 200 characters (the majority of copy-translate interactions), running the chunking pipeline produces a single chunk and exits — paying tokenizer overhead for no benefit.
+
+**How to avoid:**
+Add a fast-path guard at the entry to the chunking function:
+```swift
+guard text.count > 200 else { return [text] }
+```
+This keeps the common path identical to v0.4.0 performance.
+
+**Phase to address:** Chunked Translation (Phase 3 of v0.5.0)
+
+---
+
+### Pitfall 12: Pivot + Chunked combination requires explicit design
+
+**What goes wrong:**
+If both features are implemented independently without considering their combination, a long unsupported-pair text (e.g., 600-char JP→DE) requires N chunks × 2 pivot legs = 2N session calls. Without a clear design for this interaction, the implementation either silently skips pivot for chunked text, errors on the first chunk, or attempts to establish 2N `.translationTask()` sessions (which is not the right architecture).
+
+**Why it happens:**
+Each feature is designed in isolation. Their interaction is not considered until integration.
+
+**How to avoid:**
+Address pivot (Phase 1) and chunked (Phase 3) in sequence, not in parallel. At Phase 3 design time, explicitly test the combined path: a chunked long text with an unsupported language pair. The correct behavior is for each chunk to be translated via the pivot path (chunk→EN→target). This likely means pivot detection happens at the individual chunk level, or the first chunk detects unsupported pair and the remaining chunks use pivot without a second detection attempt.
+
+**Phase to address:** Chunked Translation (Phase 3 of v0.5.0), with pivot awareness
+
+---
+
+## Technical Debt Patterns
+
+| Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
+|----------|-------------------|----------------|-----------------|
+| Detect pivot need per-chunk (first chunk throws, all chunks retry via pivot) | Simple: no preflight, same error-driven detection pattern | 1 wasted first-leg call per chunk when pair is known-unsupported | Acceptable in v0.5.0 — pair info is not cached and preflight was explicitly removed |
+| Static shimmer (no animation) when `accessibilityReduceMotion` is true | Zero extra complexity | User who enabled reduce motion sees no feedback improvement | Acceptable — static opacity is still better than v0.4.0 |
+| Sequential chunk joining (no progressive display) | Simple coordinator — single `finish()` call | Long texts feel slower than v0.4.0 single call during chunking | Acceptable in v0.5.0 — progressive display requires coordinator state machine changes |
+| Hard 200-char fallback when no sentence boundary found | Simple, predictable | May split mid-word for CJK text without sentence punctuation | Acceptable — better to split than to fail; CJK sentence detection via NLTokenizer is reliable for common text |
+
+---
+
+## Integration Gotchas
+
+| Integration | Common Mistake | Correct Approach |
+|-------------|----------------|------------------|
+| `TranslationSession` + pivot | Calling `session.translate()` twice in one callback for different pairs | Two separate `.translationTask()` modifiers, each with its own `@State` configuration |
+| `TranslationSession.translations(from:)` | Assuming response order = input order | Always key responses by `clientIdentifier` before joining |
+| `NLTokenizer` + `nonisolated` action | Instantiating tokenizer inside the `translationAction` closure | Chunk text on `@MainActor` before session callback; pass `[String]` (Sendable) into closure |
+| `NSWindow.didResizeNotification` + shimmer | Shimmer altering view frame size on each frame | Shimmer must be a zero-layout-impact `.overlay`; verify panel frame is static during animation |
+| `TranslationErrorMapper` + pivot | Leaving error mapper in the `catch` path for unsupported pair errors | Intercept `unsupportedLanguagePairing` before the generic error mapper |
+
+---
+
+## Performance Traps
+
+| Trap | Symptoms | Prevention | When It Breaks |
+|------|----------|------------|----------------|
+| Shimmer triggers resize notifications | Panel visually jitters during loading; Instruments shows 60 `didResizeNotification` events/sec | Shimmer as size-stable overlay; check panel frame in view debugger | Immediately, on any shimmer implementation that changes layout |
+| Sequential `translate()` for chunks | 3-chunk text takes 3× longer than v0.4.0 for same character count | Use `translations(from:)` batch API | Every chunked translation |
+| No short-text bypass for chunker | All translations (including 20-char words) pay tokenizer overhead | `guard text.count > 200 else { return [text] }` | Every translation in normal usage |
+| Pivot per-chunk without caching pair support | A 600-char unsupported-pair text makes 3 wasted first-leg calls before falling back to pivot | Cache detected-unsupported flag within a request's chunk loop | Every multi-chunk unsupported-pair translation |
+
+---
+
+## UX Pitfalls
+
+| Pitfall | User Impact | Better Approach |
+|---------|-------------|-----------------|
+| Shimmer size differs from source text `PopupText` | Popup visually resizes when loading state starts, then resizes again when result arrives | Shimmer overlays existing `PopupText(text: sourceText, isMuted: true)` — same layout, same size |
+| Pivot shows intermediate English text briefly | Confusing flash of English before target language appears | Never call `onResult` between pivot legs; only call after leg 2 completes |
+| Shimmer animates during `accessibilityReduceMotion` | Violates user accessibility preference | Static opacity fallback when `accessibilityReduceMotion` is true |
+| Chunked translation with no progressive feedback | Long text feels frozen for longer than v0.4.0 | Shimmer communicates "in progress"; consider showing chunk count in loading state |
+
+---
+
+## "Looks Done But Isn't" Checklist
+
+- [ ] **Pivot:** Verify with JP→DE (or any non-EN pair) — not just EN↔JP. Error message must not appear; translated text in target language must appear.
+- [ ] **Pivot:** Verify dismiss during leg 1 → no flash of English text, no error shown. Clean dismiss.
+- [ ] **Pivot:** Verify dismiss during leg 2 → no English intermediate shown, clean dismiss.
+- [ ] **Shimmer:** Open Instruments → Core Animation and confirm 0 layout passes during shimmer animation loop.
+- [ ] **Shimmer:** Enable Reduce Motion in System Settings → Accessibility → Display. Confirm shimmer is replaced with static treatment.
+- [ ] **Shimmer:** Confirm panel does not move during shimmer (check `panel.frame` before and after 1 full animation cycle).
+- [ ] **Chunked:** Benchmark 600-char text translation time — must be ≤ 1.5× current single-call time, not 3×.
+- [ ] **Chunked:** Verify text with only whitespace/newlines between sentences does not produce empty-chunk errors.
+- [ ] **Chunked + Pivot:** Test a 600-char JP text with target=DE — confirm all chunks arrive translated into German, not English.
+- [ ] **Swift 6:** Zero concurrency warnings/errors with strict concurrency enabled for all three features.
+
+---
+
+## Recovery Strategies
+
+| Pitfall | Recovery Cost | Recovery Steps |
+|---------|---------------|----------------|
+| `unsupportedLanguagePairing` swallowed by error mapper | LOW | Add a specific `catch` clause above the generic handler; no architecture change needed |
+| Two-session pivot using wrong session | MEDIUM | Introduce second `@State` configuration + second `.translationTask()` modifier; refactor `translationAction` to accept chunk array |
+| Shimmer causing resize loop | LOW | Remove any size-changing properties from shimmer implementation; use `.overlay` + `.clipped()` |
+| Sequential translate() loop | MEDIUM | Replace with `translations(from:)` batch call; add `clientIdentifier` → index mapping |
+| `NLTokenizer` Swift 6 error | LOW | Move tokenization to synchronous pre-step on `@MainActor`; pass `[String]` chunks into closure |
+
+---
+
+## Pitfall-to-Phase Mapping
+
+| Pitfall | Prevention Phase | Verification |
+|---------|------------------|--------------|
+| `unsupportedLanguagePairing` swallowed before pivot | Phase: Pivot Translation | JP→DE test produces translated German output, not an error string |
+| Wrong session reused for pivot second leg | Phase: Pivot Translation | EN→DE leg uses explicit `source: en` configuration; German output confirmed |
+| Pivot shows intermediate English | Phase: Pivot Translation | Dismiss during leg 1 and leg 2 produce clean dismisses; no English flash |
+| Pivot + new request race | Phase: Pivot Translation | Rapid double-copy during pivot shows only the second request's result |
+| Shimmer triggers resize/reposition loop | Phase: Shimmer Animation | Panel position is static during animation; 0 resize notifications per animation frame |
+| Shimmer ignores `accessibilityReduceMotion` | Phase: Shimmer Animation | Reduce Motion enabled → static opacity instead of moving gradient |
+| Shimmer animation starts before panel visible | Phase: Shimmer Animation | Animation is smooth from first visible frame; no jump/skip on panel open |
+| Batch API not used for chunks | Phase: Chunked Translation | 600-char text benchmarks ≤1.5× single-call time |
+| `NLTokenizer` in `nonisolated` context | Phase: Chunked Translation | Zero Swift 6 strict-concurrency warnings after chunking implementation |
+| Empty chunks from tokenizer | Phase: Chunked Translation | Text with consecutive newlines translates without errors or empty segments |
+| No short-text bypass | Phase: Chunked Translation | Single-word translation performance matches v0.4.0 |
+| Pivot + Chunked interaction | Phase: Chunked Translation | 600-char JP→DE text produces fully translated German output |
 
 ---
 
 ## Sources
 
-- Apple Developer Documentation: `NSPanel`, `NSPasteboard`, activation policy APIs
-- Apple Developer Documentation: Translation framework and language availability APIs
-- Well-established macOS utility interaction patterns (menu bar apps, transient panels, clipboard-trigger workflows)
+- Apple Developer Documentation: `Translation.TranslationSession`, `.translationTask()` modifier, `TranslationSession.Configuration`, `TranslationSession.Request`
+- Apple Developer Documentation: `NaturalLanguage.NLTokenizer` — isolation and Sendable constraints
+- Swift 6 Strict Concurrency — nonisolated contexts and Sendable capture rules
+- Codebase analysis: `PopupView.swift`, `PopupController.swift`, `TranslationErrorMapper.swift`, `TranslationCoordinator.swift`
+- `NSWindow.didResizeNotification` behavior with `NSHostingView` and continuous SwiftUI animations
 
 ---
-*Pitfalls research for: macOS menu bar selected-text translation utility (Transy)*
-*Researched: 2026-03-14*
+*Pitfalls research for: Transy v0.5.0 — pivot translation, shimmer animation, chunked translation*
+*Researched: 2026-04-04*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -83,7 +83,9 @@ Implementing chunked translation as a `for chunk in chunks { let r = try await s
 `session.translate(_ string: String)` is the familiar API from existing code. The batch API (`session.translations(from: [TranslationSession.Request])`) requires learning a different call signature and response stream, so developers default to what they know.
 
 **How to avoid:**
-Use `TranslationSession.translations(from: [TranslationSession.Request])` which returns an `AsyncThrowingStream<TranslationSession.Response, Error>`. Assign a unique `clientIdentifier` to each `TranslationSession.Request` (e.g., chunk index as string). Collect responses from the stream into a dictionary keyed by `clientIdentifier`, then join in index order after the stream closes. Do not assume stream emission order equals input order — always use `clientIdentifier` to reconstruct ordering.
+Use `TranslationSession.translations(from: [TranslationSession.Request])` which returns `async throws -> [TranslationSession.Response]`. The response array is in the same order as the input request array — no `clientIdentifier` reordering is needed. Simply map the responses to their `targetText` and join in array order.
+
+Note: `translate(batch:)` is the `AsyncThrowingStream` variant whose emission order is NOT guaranteed. Do not confuse these two APIs.
 
 **Warning signs:**
 Chunked translation of a 600-char text is measurably slower than the v0.4.0 single-call translation of the same text.

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,8 +1,16 @@
 # Stack Research
 
-**Domain:** macOS menu bar utility — selected-text translation
-**Researched:** 2026-03-14
-**Confidence:** HIGH
+**Domain:** macOS menu bar utility — selected-text translation (v0.5.0 additions)
+**Researched:** 2026-04-05
+**Confidence:** HIGH (all APIs verified against macOS SDK swiftinterface files)
+
+---
+
+## Overview
+
+This document covers the **v0.5.0 stack additions** required for three new features: English pivot translation, shimmer loading animation, and chunked translation for long text. The baseline stack (Swift 6, SwiftUI, AppKit, Translation.framework, XcodeGen) is unchanged.
+
+No new package dependencies are needed. All required APIs ship with macOS 15+.
 
 ---
 
@@ -12,101 +20,174 @@
 
 | Technology | Version | Purpose | Why Recommended |
 |------------|---------|---------|-----------------|
-| Swift | 6.0 (Xcode 16) | Primary language | Direct access to AppKit, SwiftUI, and Apple's Translation framework. Strong concurrency support for trigger → popup → translate flow. |
-| SwiftUI | macOS 15+ target | Popup and settings UI | Natural fit for placeholder states, settings forms, and Translation framework integration. |
-| AppKit (`NSPanel`, `NSStatusItem`, activation policy APIs) | macOS 15+ target | Menu bar shell and non-activating popup | Required for the utility-style UX. SwiftUI alone is not enough for this class of macOS app. |
-| Translation framework | macOS 15+ | On-device translation | Chosen v1 backend for speed, privacy, and native integration. Supports automatic source-language detection and model availability APIs. |
-| Swift Package Manager | Xcode built-in | Dependency management | Native Xcode integration, low friction, no need for CocoaPods/Carthage. |
-| `UserDefaults` or `Defaults` | Optional | Settings persistence | Plain `UserDefaults` is enough initially; `Defaults` is a good upgrade once settings grow more complex. |
-
-### Configuration Notes
-
-- **Minimum deployment target:** `macOS 15+` because the Translation framework is the chosen backend.
-- **Dockless behavior:** set **`LSUIElement = YES` in `Info.plist`**, not in entitlements.
-- **Sandboxing:** Apple's Translation framework itself is sandbox-compatible. The final sandbox/capability configuration should be chosen only after Phase 1 validates the system-wide trigger-monitoring approach.
-- **Real-device testing is mandatory:** menu bar behavior, clipboard timing, and privacy-permission flows are not trustworthy in Simulator alone.
-- **No API key is required in v1:** translation is on-device.
+| Swift | 6.0 (Xcode 16) | Primary language | Unchanged from v0.4.0. Strict concurrency with `@MainActor` isolation already proven. |
+| Translation.framework | macOS 15+ | Pivot chaining + batch translation | `TranslationSession.translations(from:)` returns ordered batch results; `Configuration.invalidate()` drives pivot leg re-triggering. Both confirmed in SDK swiftinterface. |
+| NaturalLanguage.framework | macOS 10.14+ (bundled) | Sentence-boundary chunking | `NLTokenizer(unit: .sentence)` is the correct API for splitting at sentence boundaries. Present in all macOS versions above the project floor. No import overhead. |
+| SwiftUI | macOS 12+ for `TimelineView`, macOS 15+ target | Shimmer animation | `LinearGradient` + `@State`-driven `withAnimation(.linear.repeatForever)` overlay — pure SwiftUI, zero dependencies. `TimelineView(.animation)` confirmed available macOS 12+. |
 
 ---
 
-## Installation / Project Bootstrap
+## New API Surface by Feature
 
-This is a native Swift/Xcode project.
+### Feature 1: English Pivot Translation
 
-```text
-1. Create a new macOS app project in Xcode 16
-2. Set the deployment target to macOS 15.0
-3. Add LSUIElement = YES to Info.plist
-4. Create a menu bar shell and non-activating popup foundation
-5. Validate the system-wide trigger-monitoring strategy on a real Mac before freezing entitlements/capabilities
-6. Add optional SPM dependencies only when they clearly reduce code or risk
+All APIs are in the already-imported `Translation` framework.
+
+| API | Availability | Role |
+|-----|-------------|------|
+| `TranslationError.unsupportedLanguagePairing` | macOS 15+ | Trigger pivot — catch from the first `.translationTask` action instead of pre-checking |
+| `TranslationError.unsupportedSourceLanguage` | macOS 15+ | Also triggers pivot (source not identified as a supported language) |
+| `TranslationError.unsupportedTargetLanguage` | macOS 15+ | Also triggers pivot (target language has no direct model from source) |
+| `TranslationSession.Configuration(source: Locale.Language?, target: Locale.Language?)` | macOS 15+ | Pivot leg 1: `(source: nil, target: Locale.Language(languageCode: .english))`; Pivot leg 2: `(source: Locale.Language(languageCode: .english), target: targetLanguage)` |
+| `configuration.invalidate()` | macOS 15+ | Forces `.translationTask` to provide a new session with the updated language pair |
+| `Locale.Language(languageCode: .english)` | macOS 13+ | Canonical English language value for pivot. `Locale.LanguageCode.english` is an `@_alwaysEmitIntoClient` static constant confirmed in Foundation swiftinterface |
+
+**Integration pattern with existing code:**
+
+`LoadingPopupText` already uses a `@State var translationConfiguration` that drives `.translationTask`. Pivot extends this with a second state property tracking pivot phase:
+
+```swift
+enum PivotPhase: Equatable {
+    case direct
+    case pivotLeg1(originalSource: String)   // targeting English
+    case pivotLeg2(pivotText: String)         // targeting real target language
+}
+@State private var pivotPhase: PivotPhase = .direct
 ```
+
+When the action closure catches an unsupported-pair error in `.direct` phase, it sets `pivotPhase = .pivotLeg1(...)` and updates `translationConfiguration` to target English + calls `configuration.invalidate()`. This re-triggers `.translationTask` with a new session. Leg 1 success stores `pivotText` and sets `pivotPhase = .pivotLeg2(...)`, updating config to `(source: .english, target: targetLanguage)`. Leg 2 success calls `onResult`.
+
+**Do NOT use `LanguageAvailability.status()` as a preflight.** The project already removed it (causes double ML inference per request). Catch the error and retry instead.
+
+---
+
+### Feature 2: Shimmer / Skeleton Animation
+
+No new framework needed. Pure SwiftUI `ViewModifier`.
+
+| API | Availability | Role |
+|-----|-------------|------|
+| `@State var shimmerPhase: CGFloat` | All SwiftUI | Drives gradient highlight band position |
+| `withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false))` | All SwiftUI | Loops shimmer sweep continuously |
+| `LinearGradient(stops: [...], startPoint: .leading, endPoint: .trailing)` | All SwiftUI | Creates the moving highlight band |
+| `.overlay { ... }` | All SwiftUI | Composites shimmer on top of the loading placeholder |
+| `TimelineView(.animation)` | macOS 12+ | Alternative driver if `@State` approach causes animation stutter; `AnimationTimelineSchedule` confirmed available macOS 12+ in SwiftUI swiftinterface |
+
+**Integration pattern:**
+
+Apply a `ShimmerEffect` view modifier to `PopupText(text: requestContext.sourceText, isMuted: true)` inside `LoadingPopupText`. The modifier overlays a gradient with stops `[.clear → .white.opacity(0.4) → .clear]` centered at `shimmerPhase`, which animates from `-0.3` to `1.3` on `.onAppear`. Use `.blendMode(.plusLighter)` for a subtle highlight that works with both light and dark `regularMaterial` backgrounds.
+
+**Do NOT use `.redacted(reason: .placeholder)`.** It renders static grey rectangles with no animation — it is not a shimmer effect.
+
+**Do NOT add third-party shimmer packages** (e.g., `Shimmer` on SwiftPackageIndex). The effect is ~15 lines of SwiftUI; a dependency adds zero value.
+
+---
+
+### Feature 3: Chunked Translation
+
+| API | Framework | Availability | Role |
+|-----|-----------|-------------|------|
+| `NLTokenizer(unit: .sentence)` | NaturalLanguage | macOS 10.14+ | Splits text at language-aware sentence boundaries |
+| `tokenizer.string = text` | NaturalLanguage | macOS 10.14+ | Assigns text to tokenize |
+| `tokenizer.enumerateTokens(in:)` | NaturalLanguage | macOS 10.14+ | Block-based iteration over sentence ranges |
+| `TranslationSession.translations(from: [Request]) async throws -> [Response]` | Translation | macOS 15+ | **Key API**: translates a batch and returns results in the **same order as input** — no index tracking needed for reassembly. Confirmed in SDK swiftinterface. |
+| `TranslationSession.Request(sourceText: String, clientIdentifier: String?)` | Translation | macOS 15+ | One request per chunk; `clientIdentifier` can carry the chunk index for debugging |
+| `TranslationSession.Response.targetText` | Translation | macOS 15+ | Translated chunk text to rejoin |
+
+**`translations(from:)` vs `translate(batch:)` — use `translations(from:)`:**
+- `translations(from: [Request]) async throws -> [Response]` — awaits all results and returns them in input order. Reassembly is `responses.map(\.targetText).joined(separator: " ")`. Use this.
+- `translate(batch: [Request]) -> BatchResponse` — an `AsyncSequence` (yields results as they arrive, potentially out of order). Only useful if streaming partial results into the UI is a future requirement.
+
+**Chunking strategy:**
+1. `NLTokenizer` splits text into sentences.
+2. Aggregate sentences greedily into chunks ≤ 200 characters.
+3. If a single sentence exceeds 200 characters (no boundary found), split at the last whitespace before 200 chars.
+4. Pass all chunks as `[TranslationSession.Request]` to `translations(from:)` in one call.
+5. Rejoin `response.targetText` values preserving original spacing.
+
+**Where the logic lives:**
+- Sentence-splitting and chunk aggregation → new `TextChunker` type in `Transy/Translation/` (pure Foundation + NaturalLanguage, fully unit-testable).
+- Batch call → inside `LoadingPopupText.translationAction`, replacing the single `session.translate(requestContext.sourceText)` when text exceeds the chunking threshold.
+
+**New `import NaturalLanguage` required** in `TextChunker.swift` only. No existing files need import changes.
+
+---
+
+## Installation
+
+No new packages. One new framework import:
+
+```swift
+// TextChunker.swift (new file)
+import NaturalLanguage
+import Foundation
+```
+
+NaturalLanguage.framework is a system framework bundled with macOS — no SPM dependency, no entitlement required.
 
 ---
 
 ## Alternatives Considered
 
-| Recommended | Alternative | When to Use Alternative |
-|-------------|-------------|-------------------------|
-| Swift + SwiftUI/AppKit | Tauri | Only if cross-platform becomes more important than the best native macOS UX. Even then, native bridges would still be required for core macOS-only behavior. |
-| Swift + SwiftUI/AppKit | Electron | Not a good fit. The project exists partly to avoid a heavy, non-native feel. |
-| Apple Translation framework | DeepL API | Consider as a future fallback/provider option if on-device quality or language availability proves insufficient. |
-| Apple Translation framework | Google Cloud Translation / OpenAI | Consider later only if cloud translation is needed for language coverage or specialized quality tradeoffs. |
-| Plain `UserDefaults` | `Defaults` package | Use `Defaults` when the settings layer becomes more complex or needs better typing/observation ergonomics. |
+| Feature | Recommended | Alternative | Why Not |
+|---------|-------------|-------------|---------|
+| Pivot detection | Catch `TranslationError.unsupportedLanguagePairing` from session | `LanguageAvailability.status()` preflight | Removed in v0.4.0: causes double ML inference per request. Error-catch is the correct approach. |
+| Sentence splitting | `NLTokenizer(unit: .sentence)` | Manual split on `.`, `!`, `?` | Naive punctuation split breaks on abbreviations ("Dr. Smith"), ellipses, and Japanese text (`。` vs `.`). `NLTokenizer` handles all of these correctly. |
+| Chunk ordering | `translations(from:) -> [Response]` | `translate(batch:) -> BatchResponse` + clientIdentifier sort | `translations(from:)` guarantees output order matching input order. No sort logic needed. Confirmed in SDK swiftinterface. |
+| Shimmer driver | `@State` + `withAnimation(.repeatForever)` | `TimelineView(.animation)` | Both work on macOS 15+. `@State` approach is simpler. `TimelineView` is the fallback if SwiftUI transaction batching causes animation stutter on macOS. |
+| Shimmer appearance | Custom `LinearGradient` overlay | `.redacted(reason: .placeholder)` | `.redacted` is a static grey block, not animated. Wrong tool for a shimmer effect. |
 
 ---
 
-## What NOT to Use
+## What NOT to Add
 
 | Avoid | Why | Use Instead |
 |-------|-----|-------------|
-| Electron | Heavy runtime, weaker native feel, wrong fit for this utility | Swift + SwiftUI/AppKit |
-| Catalyst | Awkward for menu bar and popup-heavy utility behavior | Native AppKit + SwiftUI |
-| Cloud-first translation backend for v1 | Adds network latency and key management to the core loop | Apple Translation framework |
-| Treating `LSUIElement` as an entitlement | It's an Info.plist key, not a capability | `Info.plist` configuration |
-| Locking in CGEventTap before validation | It may introduce stricter permission/distribution constraints than necessary | Validate the simplest viable monitoring approach in Phase 1 |
+| `LanguageAvailability.status()` preflight before each translation | Double ML inference; explicitly removed from v0.4.0 for this reason | Catch `TranslationError.unsupportedLanguagePairing` in the existing error handler |
+| Third-party shimmer packages | ~15 lines of SwiftUI covers the full effect; zero dependency value | Custom `ShimmerEffect: ViewModifier` |
+| `withTaskGroup` for parallel chunk translation | `translations(from:)` handles parallelism internally; `TaskGroup` would add complexity for no gain | `TranslationSession.translations(from:)` |
+| Streaming partial chunk results to UI | Adds a `.partialResult` case to `PopupState`; not worth it for typical clipboard selections | Show shimmer until all chunks complete, then show full result |
+| `NLLanguageRecognizer` for pivot language detection | Translation framework with `source: nil` already auto-detects language; adding `NLLanguageRecognizer` duplicates work | Let `source: nil` in `Configuration` handle detection; pivot triggers only on error |
+| `TranslationSession.Strategy` (highFidelity/lowLatency) | Requires macOS 26.4 — above the project's macOS 15 floor | Not applicable for v0.5.0 |
 
 ---
 
-## Stack Patterns by Surface
+## Stack Patterns by Feature
 
-### Translation Popup
-- Use `NSPanel` with non-activating behavior
-- Host SwiftUI content via `NSHostingView` / `NSHostingController`
-- Keep the popup stateful: `.loading(sourceText)` → `.result(translatedText)` or `.error(message)`
+**Pivot — error-driven, not preflight-driven:**
+Always attempt direct translation first. Pivot is a recovery path, not a planned path. This avoids latency cost of a status check on every request. The existing `TranslationErrorMapper` already identifies unsupported-pair errors — pivot hooks into those same cases.
 
-### Trigger Monitoring
-- Start with an abstraction, not a hard-coded API assumption
-- Validate the chosen system-wide monitoring approach on a real machine
-- Keep permission onboarding and monitoring logic separate from popup/translation code
+**Shimmer — loading state only, auto-tears-down:**
+Apply `ShimmerEffect` modifier only inside `LoadingPopupText`. SwiftUI's `.id(requestID)` on the loading view already ensures the animation tears down when the view transitions out of `.loading` state. No manual cleanup needed.
 
-### Settings
-- Dedicated settings window or Settings scene for target language
-- Model availability / download guidance belongs in settings and in translation error handling
-- `UserDefaults` is sufficient initially; upgrade to `Defaults` only if it meaningfully improves implementation clarity
+**Chunking — threshold guards the fast path:**
+Skip chunking entirely for text ≤ 200 characters (the vast majority of clipboard selections). A single `guard text.count > 200 else { return [text] }` at the top of `TextChunker` keeps the common path fast and avoids unnecessary `NLTokenizer` overhead.
 
 ---
 
 ## Version Compatibility
 
-| Capability | Compatible macOS | Notes |
-|------------|------------------|-------|
-| Swift 6 / Xcode 16 | macOS 15+ target | Matches the chosen Translation framework floor |
-| Translation framework | macOS 15+ | Hard requirement for the chosen v1 backend |
-| `NSPanel`, `NSStatusItem` | Broadly supported | Stable AppKit primitives; no special risk |
-| `MenuBarExtra` | macOS 13+ | Available, but the effective app target is still macOS 15+ |
-| SwiftUI placeholder styling | Broadly supported | Suitable for the loading-state UX |
+| API | Introduced | Notes |
+|-----|-----------|-------|
+| `TranslationSession.translations(from:)` | macOS 15.0 | Returns ordered `[Response]`; confirmed in SDK swiftinterface |
+| `TranslationSession.translate(batch:)` | macOS 15.0 | Returns `BatchResponse` (AsyncSequence); out-of-order — do not use for chunking |
+| `TranslationSession.Configuration.invalidate()` | macOS 15.0 | Required for pivot leg re-triggering |
+| `Locale.Language(languageCode: .english)` | macOS 13.0 | `Locale.LanguageCode.english` is `@_alwaysEmitIntoClient`; confirmed in Foundation swiftinterface |
+| `NLTokenizer(unit: .sentence)` | macOS 10.14 | Well below project floor; zero risk |
+| `TimelineView(.animation)` | macOS 12.0 | Below project floor; available if needed as shimmer fallback |
+| `LinearGradient` + `withAnimation` | macOS 11.0 | Below project floor; available |
+| `TranslationSession.Strategy` (highFidelity/lowLatency) | macOS 26.4 | **Do not use** — above the project's macOS 15 floor |
 
 ---
 
 ## Sources
 
-- Apple Developer Documentation: Translation framework
-- Apple Developer Documentation: Translating text within your app
-- Apple Developer Documentation: `LanguageAvailability.supportedLanguages`
-- Apple Developer Documentation: `NSPanel`, `NSStatusItem`, activation policy APIs
-- WWDC24: Meet the Translation API
+- `Translation.framework` — `arm64e-apple-macos.swiftinterface` from Xcode SDK (Translation version 365.8.2) — verified all `TranslationSession`, `TranslationError`, `LanguageAvailability` API signatures
+- `NaturalLanguage.framework` — `NLTokenizer.h` from Xcode SDK — verified `NLTokenUnit.sentence`, `enumerateTokensInRange:usingBlock:`
+- `Foundation.framework` — `arm64e-apple-macos.swiftinterface` from Xcode SDK — verified `Locale.Language(languageCode:)`, `Locale.LanguageCode.english`
+- `SwiftUI.framework` — `arm64e-apple-macos.swiftinterface` from Xcode SDK — verified `TimelineView`, `AnimationTimelineSchedule` availability (macOS 12+)
+- `.planning/PROJECT.md` — confirmed removal of `LanguageAvailability.status()` preflight in v0.4.0
 
 ---
-*Stack research for: macOS menu bar selected-text translation utility (Transy)*
-*Researched: 2026-03-14*
+*Stack research for: Transy v0.5.0 — pivot translation, shimmer animation, chunked translation*
+*Researched: 2026-04-05*

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,17 +1,19 @@
 # Project Research Summary
 
-**Project:** Transy
-**Domain:** macOS menu bar utility — selected-text translation (Japanese/English)
-**Researched:** 2026-03-14
-**Confidence:** HIGH
+**Project:** Transy v0.5.0 — Translation Quality Milestone
+**Domain:** macOS menu bar utility — selected-text translation (v0.5.0 additions: pivot, shimmer, chunked)
+**Researched:** 2026-04-06
+**Confidence:** HIGH (all APIs verified against macOS SDK swiftinterface files; architecture derived from direct codebase read)
+
+---
 
 ## Executive Summary
 
-Transy should be built as a **Swift 6 + SwiftUI/AppKit hybrid**. AppKit owns the system-integration surfaces (`NSPanel`, menu bar presence, global event monitoring), while SwiftUI renders the popup and settings views. This is the right architectural fit for a lightweight macOS utility that must feel native and avoid stealing focus.
+The v0.5.0 milestone adds three features to the shipped v0.4.0 foundation: **English pivot translation** (silently retries unsupported language pairs via English), **shimmer loading animation** (replaces the static muted placeholder with an animated gradient sweep), and **chunked translation** (splits long texts at sentence boundaries before batch-translating). All three are required to ship the milestone. Critically, **no new package dependencies are needed** — the complete implementation uses Apple Translation.framework, NaturalLanguage.framework (bundled since macOS 10.14), and pure SwiftUI, all already within the project's macOS 15 deployment floor.
 
-After backend comparison, the chosen initial translation backend is **Apple's Translation framework** on **macOS 15+**. That decision optimizes for on-device speed, privacy, and platform-native UX rather than cloud-provider flexibility. The core differentiator remains unchanged: open the popup immediately with the source text as a placeholder/skeleton state, then replace it with the translated result when translation completes.
+The central architectural insight is that Apple Translation sessions are **view-scoped, not instantiable directly**. This shapes every design decision. Pivot requires two separate `.translationTask()` modifiers in `LoadingPopupText` (one per language pair) coordinated through a new `PivotTranslationState` `@Observable` class — not a single session called twice. Chunking must use the batch API `TranslationSession.translations(from: [Request])`, which returns results in **guaranteed input order** (confirmed in SDK swiftinterface), not sequential `translate()` loops which would multiply latency N×. The `NLTokenizer(unit: .sentence)` used for sentence-boundary splitting must run synchronously on `@MainActor` before entering the `nonisolated` translation action, because `NLTokenizer` is not `Sendable` under Swift 6 strict concurrency.
 
-The highest-risk work is not the translation engine itself. The real Phase 1 risks are validating the chosen system-wide trigger approach, handling privacy permissions clearly, making the popup truly non-activating, and avoiding clipboard corruption or stale reads.
+The highest risk is **shimmer triggering the NSPanel resize loop**: `PopupController` has a `NotificationCenter` observer for `NSWindow.didResizeNotification` that calls `repositionPanel()` on every event. Any shimmer implementation that changes the view's layout frame will fire that notification at 60fps, visibly jittering the panel. Shimmer must be implemented as a zero-layout-impact `.overlay` that never alters the underlying `PopupText` dimensions. Build order recommendation: **Phase 14 Shimmer → Phase 15 Chunked → Phase 16 Pivot**, with shimmer's isolation making it a safe first deliverable and pivot's two-session state machine warranting the most careful integration.
 
 ---
 
@@ -19,77 +21,165 @@ The highest-risk work is not the translation engine itself. The real Phase 1 ris
 
 ### Recommended Stack
 
-The native Apple stack is the clear choice for v1:
+No new packages. All additions are system-framework imports already available at the macOS 15 deployment floor.
 
-- **Swift 6 / Xcode 16** — primary language and tooling; gives direct access to AppKit, SwiftUI, and the Translation framework
-- **SwiftUI** — popup and settings rendering; also the native integration point for the Translation framework APIs
-- **AppKit (`NSPanel`, `NSStatusItem`, activation policy control)** — required for the menu bar shell and non-activating popup behavior
-- **Apple Translation framework** — on-device translation, automatic source-language detection, system-managed model downloads
-- **System-wide trigger monitoring strategy validated in Phase 1** — use the simplest approach that reliably supports double-`Command+C` without compromising UX or distribution goals
-- **SPM** — dependency management; no CocoaPods/Carthage required
-- **Optional `Defaults` package** — nice-to-have for typed settings, but not mandatory from day one
+**Core technologies (v0.5.0 additions only):**
+- **`Translation.framework`** (already imported) — `TranslationSession.translations(from:)` for batch chunked translation; `Configuration.invalidate()` for pivot leg re-triggering; `TranslationError.unsupportedLanguagePairing/unsupportedSourceLanguage/unsupportedTargetLanguage` for error-driven pivot detection.
+- **`NaturalLanguage.framework`** (`import NaturalLanguage` in new `TextChunker.swift` only) — `NLTokenizer(unit: .sentence)` for language-aware sentence-boundary splitting. Bundled since macOS 10.14; no entitlement; no SPM dependency.
+- **SwiftUI** (already imported) — pure `ViewModifier` shimmer via `LinearGradient` + `withAnimation(.linear.repeatForever(autoreverses: false))`; `TimelineView(.animation)` available as a fallback shimmer driver if needed.
 
-**Critical version/config requirements:**
-- **macOS 15+** minimum deployment target because the Translation framework is the chosen backend
-- **`LSUIElement = YES` in `Info.plist`** to keep the app out of the Dock and Cmd+Tab switcher
-- **Translation framework is sandbox-compatible**; however, the final trigger-monitoring approach and its permission model must be validated before hard-coding the app's sandbox/capability strategy
-- **No API key is required for v1** because translation is on-device
+**Critical API details verified in SDK swiftinterface:**
+- `translations(from: [Request]) -> [Response]` returns results **in the same order as input** — no `clientIdentifier` sort needed for reassembly. (Note: PITFALLS.md Pitfall 4 contradicts this; STACK.md's SDK-verified finding takes precedence.)
+- `TranslationSession.Strategy` (highFidelity/lowLatency) requires macOS 26.4 — **do not use** (above the project floor).
+- `Locale.Language(languageCode: .english)` is available from macOS 13 (`@_alwaysEmitIntoClient` static constant in Foundation).
+- `LanguageAvailability.status()` must **not** be used as a preflight — explicitly removed in v0.4.0 to eliminate double ML inference per request.
 
 ### Expected Features
 
-**Must have for v1 launch:**
-- Double-`Command+C` trigger for selected text in another macOS app
-- Clear onboarding for whatever privacy permissions the chosen monitoring approach requires
-- Non-activating floating popup that does not steal focus from the source app
-- Source text shown immediately in a placeholder/skeleton loading state
-- On-device Apple translation into the configured target language
-- Automatic source-language detection (no manual source picker)
-- Target language selection in a dedicated settings window
-- Clear model-availability / download guidance when required Apple language models are missing
-- Escape + click-outside dismissal
-- Menu bar residence with no Dock icon
+**Must have — all define v0.5.0 (no deferral):**
+- **English pivot translation** — unsupported pairs (JP→DE, ZH→FR, etc.) silently route via English; user receives target-language result with no error, no intermediate English flash, no "via English" label.
+- **Shimmer/skeleton animation** — `LinearGradient` overlay sweeps across the muted source text at ~1.5–2s per cycle; respects `accessibilityReduceMotion`; stops naturally when `LoadingPopupText` is replaced.
+- **Chunked translation** — texts >200 chars split at sentence boundaries via `NLTokenizer`; all chunks submitted as a single batch via `translations(from:)`; results joined preserving original separators.
 
-**Should have after the core loop is validated (v1.x):**
-- Launch at Login toggle
-- Copy translation action in the popup
-- Provider abstraction exposed in settings for future external-provider fallback
+**Differentiators (built-in to the above):**
+- Transparent pivot — no user-visible indication that English is being used as an intermediary.
+- Shimmer preserves source text readability — the shimmer overlays the muted source text, not blank placeholder bars. This is a deliberate design principle carried from v0.4.0.
+- Sentence-boundary chunking — `NLTokenizer` handles `。!?.！？` plus language-aware boundaries; naïve character splits are explicitly rejected.
 
-**Defer to v2+:**
-- Popup positioning near the current selection (AXUIElement-based positioning)
-- Custom shortcut remapping UI
-- OCR / screenshot translation
+**Anti-features (explicitly do not build):**
+- "Translating via English…" progress label — reveals implementation detail; surfaces failure paths without benefit.
+- Parallel chunk translation with `TaskGroup` — `translations(from:)` handles parallelism internally; `TaskGroup` adds complexity for no gain.
+- Per-chunk error recovery — over-engineering; the failure modes are pair-level, not chunk-level.
+- Configurable chunk size in Settings — the 200-char threshold is an implementation constant, not a user-facing knob.
+- Animated pivot phase progress — two on-device inferences take ~300ms; phase indicators are visible only for a flash.
+- `TranslationSession.Strategy` (highFidelity/lowLatency) — requires macOS 26.4.
 
 ### Architecture Approach
 
-The architecture should follow the **AppKit shell + SwiftUI leaf nodes** pattern:
+All three features are **additive changes to `LoadingPopupText`** in `PopupView.swift`; `TranslationCoordinator`, `PopupController`, `AppDelegate`, and `TextNormalization` are **unchanged**. The existing `PopupState` state machine, `requestID` race guard, and `configuration.invalidate()` mechanism are all reused without modification.
 
-- **App shell:** menu bar item, popup window controller, activation policy, settings window lifecycle
-- **Trigger layer:** detects double-`Command+C`, captures the selected text safely, and restores the previous clipboard contents
-- **Coordinator layer:** shows the popup immediately in `.loading(sourceText)` state, requests translation, and then transitions the popup to `.result` or `.error`
-- **Translation layer:** define a `TranslationService` protocol from day one, with an `AppleTranslationClient` as the initial implementation; this keeps future provider fallback possible without refactoring the coordinator/UI boundary
-- **Settings layer:** stores the target language and presents model-availability guidance; no API key handling is needed in v1
+**New files:**
+1. `Transy/Translation/PivotTranslationState.swift` — `@MainActor @Observable final class PivotTranslationState` holding `PivotPhase` enum (`.direct`, `.firstLeg`, `.secondLeg(intermediate: String)`). Encapsulates pivot as a translation-engine detail, not a coordinator concern.
+2. `Transy/Popup/ShimmerModifier.swift` — `ShimmerModifier: ViewModifier` + `View.shimmer()` extension. Pure SwiftUI struct; no actor isolation; no state machine.
+3. `Transy/Translation/TextChunker.swift` — `enum TextChunker` with `static func chunks(from:maxLength:) -> [String]`. Fast path: `guard text.count > 200 else { return [text] }`. Pure `Foundation` + `NaturalLanguage`; fully unit-testable with no Translation framework dependency.
+
+**Modified files:**
+- `Transy/Popup/PopupView.swift` (all three features touch `LoadingPopupText`): add `@State private var pivotState = PivotTranslationState()`, second `.translationTask(pivotConfiguration, action:)` modifier, `.shimmer()` on `PopupText(sourceText, isMuted: true)`, and chunk loop in the translation action.
+- `Transy/Translation/TranslationErrorMapper.swift`: extract `static func isPivotableError(_ error: any Error) -> Bool` from the existing `unsupportedLanguagePairing` match.
+
+**Pivot data flow:**
+```
+translationAction → catch unsupportedLanguagePairing
+  → pivotState.phase = .firstLeg
+  → .onChange(pivotState.phase) → invalidate config to (source: nil, target: .english)
+  → translationAction fires again → intermediate English result
+  → pivotState.phase = .secondLeg(intermediate)
+  → .onChange → invalidate config to (source: .english, target: targetLanguage)
+  → translationAction fires again → onResult(finalTranslation)
+```
+
+**Swift 6 concurrency invariants:**
+- `translationAction` remains `nonisolated static`; all `@Sendable` callback closures route `@MainActor` mutations through `await MainActor.run {}`.
+- `PivotTranslationState` is `@MainActor`-isolated → `Sendable` as a reference type; safe to capture in `@Sendable` closures.
+- `PivotPhase` contains only `String` → satisfies `Sendable`.
+- `NLTokenizer` (non-`Sendable`) must run synchronously on `@MainActor` inside `LoadingPopupText.body` **before** the `nonisolated translationAction` closure captures the resulting `[String]` chunk array.
 
 ### Critical Pitfalls
 
-1. **Popup stealing focus** — the popup must be an `NSPanel` configured to avoid activating the app; a normal `NSWindow` / `WindowGroup` is the wrong primitive here.
-2. **Clipboard race on capture** — the source app may not have written the copied text yet when the trigger fires; Phase 2 must validate a small delayed read strategy before capture is considered correct.
-3. **Clipboard trust erosion** — previous clipboard contents must be restored after capture so the app does not silently destroy the user's clipboard.
-4. **Permission ambiguity** — the trigger-monitoring API choice determines whether only Accessibility or additional privacy permissions are needed; this must be validated early and documented clearly in the implementation plan.
-5. **Model availability** — Apple Translation may require system model downloads for a language pair; the app must surface this as guidance, not as a silent failure.
-6. **macOS floor mismatch** — Translation framework usage hard-locks the project to macOS 15+.
+1. **`unsupportedLanguagePairing` swallowed by `TranslationErrorMapper` before pivot fires** (Critical) — the existing generic catch block converts this error to a display string and calls `onError`, terminating before any pivot logic runs. Fix: add a specific `catch TranslationError.unsupportedLanguagePairing, ...` clause *above* the generic handler; invoke pivot from there; only fall through to `onError` if pivot itself fails. (PITFALLS.md §1)
+
+2. **Shimmer triggers `repositionPanel()` at 60fps** (Critical) — `PopupController` observes `NSWindow.didResizeNotification` and calls `panel.setFrameOrigin()` on every event. Any shimmer that alters view layout on each frame (padding change, different intrinsic size) fires this 60× per second, visibly jittering the panel position. Fix: shimmer must be a `LinearGradient` `.overlay` with `.clipped()`; the underlying `PopupText` dimensions must be identical to non-shimmer state; verify panel frame is static during animation in the Xcode view debugger. (PITFALLS.md §3)
+
+3. **Two pivot legs cannot share one `.translationTask()` session** (Critical) — `TranslationSession.Configuration` encodes the source/target language pair; one session = one pair; calling `session.translate()` twice in the same callback for different pairs silently uses the wrong model. Fix: introduce a second `@State private var pivotConfiguration: TranslationSession.Configuration?` and a second `.translationTask(pivotConfiguration, action:)` modifier; the second modifier activates only when pivot is needed. Leg 2 config must use `source: Locale.Language(identifier: "en")` explicitly — NOT `source: nil` (auto-detect misidentifies short English intermediates). (PITFALLS.md §2)
+
+4. **`NLTokenizer` in `nonisolated` context → Swift 6 concurrency error** (Critical) — `NLTokenizer` is an Obj-C class not conforming to `Sendable`; instantiating it inside `nonisolated translationAction` will produce `"Sending 'tokenizer' risks causing data races"`. Fix: perform chunking synchronously on `@MainActor` in `LoadingPopupText.body` before the session callback; pass the resulting `[String]` (which is `Sendable`) into the closure. (PITFALLS.md §5)
+
+5. **Sequential `translate()` loop for chunks multiplies latency N×** (Critical) — a `for chunk in chunks { let r = try await session.translate(chunk) }` loop makes N sequential inference calls; a 3-chunk text is 3× slower than v0.4.0. Fix: use `session.translations(from: [TranslationSession.Request])` which submits all chunks in one batch call and returns ordered `[Response]`. (PITFALLS.md §4 / STACK.md §Feature 3)
+
+6. **Pivot shows intermediate English text on dismiss** (Moderate) — if `onResult` is called after leg 1 (even for debugging), users may see raw English output before dismissal tears down the view. Fix: `onResult` must be called exactly once — after leg 2. (PITFALLS.md §6)
+
+7. **Shimmer animation starts before panel is visible** (Moderate) — starting animation in `.task` may fire before the panel's 0.15s `alphaValue` fade-in completes, causing a static or jumped shimmer. Fix: use `.onAppear`, not `.task`. (PITFALLS.md §9)
+
+8. **`accessibilityReduceMotion` ignored by shimmer** (Moderate) — violates user accessibility preference. Fix: read `@Environment(\.accessibilityReduceMotion)` and substitute a static `opacity(0.4)` treatment when true. (PITFALLS.md §10)
 
 ---
 
 ## Implications for Roadmap
 
-The current 4-phase roadmap is directionally correct once the research summary is reconciled with the Apple Translation decision:
+Based on combined research, the v0.5.0 milestone maps cleanly to three sequential implementation phases. The ordering is driven by dependency and integration risk, not by feature priority (all three are P1).
 
-- **Phase 1 — App Shell:** set the macOS 15 target, configure `LSUIElement`, create the menu bar shell, and validate the trigger-monitoring + sandbox/capability strategy
-- **Phase 2 — Trigger & Popup:** implement the double-`Command+C` trigger, permission guidance, delayed clipboard capture, clipboard restoration, and non-activating popup
-- **Phase 3 — Translation Loop:** integrate Apple Translation, automatic source-language detection, and stale-request/error handling
-- **Phase 4 — Settings:** add target language settings and model download guidance
+### Phase 14: Shimmer Animation
 
-The main cleanup required after research is not a new roadmap shape — it is **document consistency**. Older cloud-backend assumptions should not drive Phase 1 decisions anymore.
+**Rationale:** Most isolated feature — zero logic dependencies, zero state machine changes, no Translation framework surface. Building shimmer first means the loading UI looks polished during testing of the other two features (pivot and chunked both extend loading duration, making shimmer more valuable and visible). Low risk makes it the safest first deliverable.
+
+**Delivers:** `ShimmerModifier.swift` (new); one-line change to `LoadingPopupText.body`; `accessibilityReduceMotion` support.
+
+**Addresses:** Shimmer animation (table stakes), shimmer-preserves-source-text differentiator.
+
+**Must avoid:**
+- Shimmer altering view layout frame (NSPanel resize loop at 60fps — Pitfall 3)
+- Starting animation in `.task` instead of `.onAppear` (Pitfall 9)
+- Ignoring `accessibilityReduceMotion` (Pitfall 10)
+
+**Research flag:** None — well-documented SwiftUI animation pattern; standard `ViewModifier` approach.
+
+---
+
+### Phase 15: Chunked Translation
+
+**Rationale:** Self-contained in `TextChunker.swift` + `translationAction`; does not change the view state machine; its test suite validates `TextChunker` with zero Translation framework dependency. Must be built before pivot because pivot's combined path (long unsupported-pair text) requires `TextChunker` to exist inside each pivot leg's action. Building chunking first means pivot integration is complete, not deferred.
+
+**Delivers:** `TextChunker.swift` (new); `translationAction` extended with chunk loop using `translations(from:)` batch API; `import NaturalLanguage` in `TextChunker.swift` only.
+
+**Addresses:** Chunked translation (table stakes), sentence-boundary chunking differentiator.
+
+**Must avoid:**
+- Sequential `translate()` loop instead of `translations(from:)` batch API (Pitfall 4 / latency N× trap)
+- `NLTokenizer` instantiated inside `nonisolated translationAction` (Swift 6 Pitfall 5) — must run on `@MainActor` before session callback
+- Missing short-text bypass: `guard text.count > 200 else { return [text] }` (Pitfall 11 / perf trap)
+- Passing empty or whitespace-only chunks to `translate()` (Pitfall 8)
+
+**Research flag:** None — `TextChunker` is a pure utility; `NLTokenizer` patterns are well-documented; batch API signature verified in SDK.
+
+---
+
+### Phase 16: English Pivot Translation
+
+**Rationale:** Highest complexity due to two-session view architecture and state machine in `LoadingPopupText`. Benefits from both shimmer (running throughout both legs without modification) and chunked translation (pivot legs reuse `TextChunker` transparently) being complete. Pivot's `PivotTranslationState` `@Observable` class mirrors existing patterns; the risk is contained within `LoadingPopupText` + `TranslationErrorMapper`.
+
+**Delivers:** `PivotTranslationState.swift` (new); `LoadingPopupText` extended with second `@State pivotConfiguration` + second `.translationTask` modifier; `TranslationErrorMapper.isPivotableError(_:)` extracted.
+
+**Addresses:** English pivot translation (table stakes), transparent pivot differentiator, JP→DE / ZH→FR unblocked.
+
+**Must avoid:**
+- `unsupportedLanguagePairing` consumed by existing error mapper before pivot fires (Pitfall 1 — split catch block)
+- Leg 2 session using `source: nil` (auto-detect misidentifies short English intermediates; must use explicit `source: Locale.Language(identifier: "en")`) (Pitfall 2)
+- `onResult` called between pivot legs (intermediate English flash) (Pitfall 6)
+- Pivot state (`@State pivotConfiguration`) in a parent view rather than inside `LoadingPopupText` — must be destroyed with the view identity on new `requestID` (Pitfall 7)
+- Pivot + chunked combined path not explicitly designed: 600-char JP→DE requires all chunks to pivot; detect unsupported pair on first chunk, then apply pivot strategy to remaining chunks without re-detecting (Pitfall 12)
+
+**Research flag:** Needs careful integration review — two-session coordination is the only unexplored Apple Translation surface in this milestone. The `configuration.invalidate()` mechanism already works (proven by the existing per-request flow); multi-invalidation within a single user trigger is an extension of the same mechanism, so confidence is HIGH but implementation correctness must be verified with JP→DE and ZH→FR test cases.
+
+---
+
+### Phase Ordering Rationale
+
+- **Shimmer first** because it is entirely decoupled; its code paths do not interact with Translation framework state; having it live makes testing of phases 15 and 16 significantly more pleasant (animated feedback during longer loading states).
+- **Chunked second** because `TextChunker` is a self-contained pure utility, testable without any framework dependency; and because pivot's combined long-text path requires `TextChunker` to already exist inside the translation action closure before pivot is integrated.
+- **Pivot third** because it has the highest integration complexity; it benefits from shimmer already handling the extended loading duration across two legs; and from chunked already being in place for the pivot+chunked combined path. Building pivot last means all its dependencies are stable.
+
+This order also isolates risk: shimmer and chunked can be merged and shipped independently if needed, without blocking pivot.
+
+---
+
+### Research Flags
+
+Phases with standard patterns (no additional phase research needed):
+- **Phase 14 (Shimmer):** Well-documented SwiftUI `ViewModifier` pattern; only risk is NSPanel resize behavior (known, mitigated by zero-layout-impact overlay).
+- **Phase 15 (Chunked):** `NLTokenizer` and `translations(from:)` batch API both verified against SDK; `TextChunker` is a pure utility with straightforward unit tests.
+
+Phases that benefit from careful pre-implementation review (not full research, but deliberate design review):
+- **Phase 16 (Pivot):** The two-`.translationTask` coordination pattern has not been exercised in the codebase before. The `configuration.invalidate()` mechanism is proven for the single-request case; its sequential multi-invalidation behavior within one user trigger is HIGH confidence from the research but should be prototyped and verified before full implementation. Specifically: confirm SwiftUI does not coalesce rapid successive `configuration.invalidate()` calls, and verify that `.id(requestID)` on `LoadingPopupText` tears down both `.translationTask` modifiers cleanly when a new clipboard event arrives mid-pivot.
 
 ---
 
@@ -97,35 +187,39 @@ The main cleanup required after research is not a new roadmap shape — it is **
 
 | Area | Confidence | Notes |
 |------|------------|-------|
-| Stack | HIGH | SwiftUI/AppKit + Apple Translation is directly supported by Apple on macOS 15+ |
-| Core UX | HIGH | Non-activating popup + immediate placeholder remains the right interaction model |
-| Roadmap shape | HIGH | 4 phases still match the chosen backend and current requirements |
-| Trigger permissions | MEDIUM | Needs real-device validation because permission behavior depends on the final monitoring API |
-| Popup positioning | MEDIUM | Fixed position is acceptable for v1, but should be validated in practice |
+| Stack | HIGH | All APIs verified against arm64e macOS SDK swiftinterface files; no inferred behavior |
+| Features | HIGH | Derived from direct codebase analysis + Apple Translation framework constraints; edge cases documented with specific implementation notes |
+| Architecture | HIGH (existing) / MEDIUM (pivot multi-session) | Existing v0.4.0 architecture read directly from codebase; pivot two-`.translationTask` coordination is architecturally sound but not yet exercised |
+| Pitfalls | HIGH | All critical pitfalls derived from actual code paths in `PopupView.swift`, `PopupController.swift`, `TranslationErrorMapper.swift`; NSPanel resize behavior is a known macOS pattern |
 
 **Overall confidence: HIGH**
 
 ### Gaps to Address
 
-- Validate the exact monitoring API and the privacy-permission combination it requires before Phase 1 implementation locks in app capabilities.
-- Confirm the delayed clipboard-read strategy with real-device testing.
-- Decide whether `Defaults` is worth adding in Phase 1 or whether plain `UserDefaults` is sufficient until settings become more complex.
+- **`translations(from:)` ordering guarantee vs. `clientIdentifier` sort** — STACK.md (SDK-verified) states output order matches input order; PITFALLS.md §4 contradicts this and recommends keying by `clientIdentifier`. STACK.md's SDK-verified finding takes precedence. Verify empirically during Phase 15 implementation with a multi-chunk text and assert response order.
+- **Concurrent `.translationTask()` safety** — it is undocumented whether multiple concurrent `session.translate()` calls on the same `TranslationSession` instance are safe. The chosen sequential chunk loop avoids this concern; document the decision in `TextChunker.swift` with a comment.
+- **Pivot multi-invalidation behavior** — `configuration.invalidate()` is proven for the single-request case; behavior with 2–3 rapid sequential invalidations within one user trigger is HIGH confidence from research but should be confirmed early in Phase 16 with a prototype before full state machine build-out.
+- **Shimmer on light vs. dark system appearance** — `Color.white.opacity(0.25)` peak works for dark `regularMaterial`; verify on light system appearance during Phase 14 and adjust opacity/gradient stops if needed.
 
 ---
 
 ## Sources
 
-### Primary
-- Apple Developer Documentation: Translation framework — https://developer.apple.com/documentation/translation
-- Apple Developer Documentation: Translating text within your app — https://developer.apple.com/documentation/translation/translating-text-within-your-app
-- Apple Developer Documentation: `LanguageAvailability.supportedLanguages` — https://developer.apple.com/documentation/translation/languageavailability/supportedlanguages
-- Apple Developer Documentation: `NSPanel`, `NSStatusItem`, `NSEvent.addGlobalMonitorForEvents`, activation policy APIs
+### Primary (HIGH confidence — SDK-verified)
+- `Translation.framework` — `arm64e-apple-macos.swiftinterface` (Translation version 365.8.2) — `TranslationSession`, `TranslationError`, `LanguageAvailability`, `translations(from:)` ordering guarantee
+- `NaturalLanguage.framework` — `NLTokenizer.h` — `NLTokenUnit.sentence`, `enumerateTokensInRange:usingBlock:`
+- `Foundation.framework` — `arm64e-apple-macos.swiftinterface` — `Locale.Language(languageCode:)`, `Locale.LanguageCode.english`
+- `SwiftUI.framework` — `arm64e-apple-macos.swiftinterface` — `TimelineView`, `AnimationTimelineSchedule` availability (macOS 12+)
+- Codebase direct read — `PopupView.swift`, `TranslationCoordinator.swift`, `PopupController.swift`, `TranslationErrorMapper.swift`, `SupportedLanguageOption.swift` — verified 2026-04-06
 
-### Secondary
-- WWDC24: Meet the Translation API — https://developer.apple.com/videos/play/wwdc2024/10117/
-- Competitor/product references: DeepL, Bob, PopClip — useful for UX comparison, not as the chosen backend
+### Secondary (MEDIUM confidence)
+- `.planning/PROJECT.md` — confirmed removal of `LanguageAvailability.status()` preflight in v0.4.0
+- Apple Developer Documentation: Translation framework, `NSPanel`, `NSWindow.didResizeNotification`
+- WWDC24: Meet the Translation API
+- macOS HIG — Reduced Motion accessibility guideline
 
 ---
-*Research completed: 2026-03-14*
-*Reconciled after backend selection: Apple Translation framework*
+*Research completed: 2026-04-06*
+*Covers: Transy v0.5.0 — pivot translation, shimmer animation, chunked translation*
+*Supersedes: 2026-03-14 baseline research summary (v0.4.0)*
 *Ready for roadmap: yes*

--- a/.planning/todos/completed/2026-03-15-add-translation-model-install-guidance.md
+++ b/.planning/todos/completed/2026-03-15-add-translation-model-install-guidance.md
@@ -1,0 +1,18 @@
+---
+created: 2026-03-15T02:06:07.613Z
+title: Add translation model install guidance
+area: planning
+files:
+  - .planning/phases/03-translation-loop/03-02-PLAN.md
+  - .planning/ROADMAP.md
+  - Transy/Popup/PopupView.swift
+  - Transy/Settings/SettingsView.swift
+---
+
+## Problem
+
+During Phase 3 live verification, Transy correctly showed the inline error `Translation model not installed.` for a normal Japanese-to-English translation attempt, but there is currently no user-facing guidance explaining where Apple translation models are installed on macOS. This leaves the user stuck at the correct error state without a clear next step, and it blocks completion of the happy-path translation loop until the model is installed out of band.
+
+## Solution
+
+Add a future user-facing guidance path for Apple translation model installation. The likely home is Phase 4 settings/model management, but the exact UX can be decided later. At minimum, capture the install path (`System Settings > General > Language & Region > Translation Languages`) and surface it in a way that fits the quiet Transy UX, ideally without introducing surprise Apple-owned prompts during the normal Phase 3 popup flow.


### PR DESCRIPTION
Initializes v0.5.0 milestone planning artifacts.

## Changes
- `PROJECT.md` updated with v0.5.0 milestone goals and research notes
- `STATE.md` reset for new milestone
- `REQUIREMENTS.md` created with 9 requirements across 3 features (SHM/CHK/PIV)
- `ROADMAP.md` extended with phases 14–16
- `todos/completed/` — translation model install guidance marked done
- Research artifacts committed (SUMMARY.md, STACK.md, ARCHITECTURE.md, FEATURES.md, PITFALLS.md)

## GitHub Issues
- Milestone #2: v0.5.0 Translation Quality
- Tracking Issue: #27
- Phase 14 (Shimmer): #28
- Phase 15 (Chunked): #29
- Phase 16 (Pivot): #30

Relates to #27