### PR TITLE
Phase 15: Chunked Translation

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -8,7 +8,7 @@ Transy is a lightweight macOS menu bar translator for personal Japanese/English 
 
 Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
 
-## Current State: v0.5.0 IN PROGRESS — Phase 14 complete (shimmer animation)
+## Current State: v0.5.0 IN PROGRESS — Phase 15 complete (chunked translation)
 
 **Shipped:** 2026-04-04 — 13 phases, 22 plans, 4 milestones
 
@@ -82,4 +82,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-12 after Phase 14 shimmer animation completion*
+*Last updated: 2026-04-12 after Phase 15 chunked translation completion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -92,7 +92,7 @@ Plans:
 **Plans**: 2 plans
 
 Plans:
-- [ ] 15-01-PLAN.md — TextChunker TDD: sentence-boundary chunking with separator recording
+- [x] 15-01-PLAN.md — TextChunker TDD: sentence-boundary chunking with separator recording
 - [ ] 15-02-PLAN.md — Wire chunked batch translation into PopupView
 
 ---
@@ -125,7 +125,7 @@ Plans:
 | 12. Clipboard Monitoring | v0.4.0 | 2/2 | Complete | 2026-04-04 |
 | 13. Translation Download UI | v0.4.0 | 1/1 | Complete | 2026-04-04 |
 | 14. Shimmer Animation | v0.5.0 | 2/2 | Complete    | 2026-04-12 |
-| 15. Chunked Translation | v0.5.0 | 0/2 | Not started | — |
+| 15. Chunked Translation | v0.5.0 | 1/2 | In Progress|  |
 | 16. Pivot Translation | v0.5.0 | 0/2 | Not started | — |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -58,7 +58,7 @@ Full details: [milestones/v0.4.0-ROADMAP.md](milestones/v0.4.0-ROADMAP.md)
 ### 🚧 v0.5.0 Translation Quality
 
 - [x] **Phase 14: Shimmer Animation** — Animated skeleton shimmer during translation loading state (completed 2026-04-12)
-- [ ] **Phase 15: Chunked Translation** — Split long text at sentence boundaries and translate as a batch
+- [x] **Phase 15: Chunked Translation** — Split long text at sentence boundaries and translate as a batch (completed 2026-04-12)
 - [ ] **Phase 16: Pivot Translation** — Chain source→EN→target when language pair is unsupported
 
 ## Phase Details
@@ -93,7 +93,7 @@ Plans:
 
 Plans:
 - [x] 15-01-PLAN.md — TextChunker TDD: sentence-boundary chunking with separator recording
-- [ ] 15-02-PLAN.md — Wire chunked batch translation into PopupView
+- [x] 15-02-PLAN.md — Wire chunked batch translation into PopupView
 
 ---
 
@@ -125,7 +125,7 @@ Plans:
 | 12. Clipboard Monitoring | v0.4.0 | 2/2 | Complete | 2026-04-04 |
 | 13. Translation Download UI | v0.4.0 | 1/1 | Complete | 2026-04-04 |
 | 14. Shimmer Animation | v0.5.0 | 2/2 | Complete    | 2026-04-12 |
-| 15. Chunked Translation | v0.5.0 | 1/2 | In Progress|  |
+| 15. Chunked Translation | v0.5.0 | 2/2 | Complete   | 2026-04-12 |
 | 16. Pivot Translation | v0.5.0 | 0/2 | Not started | — |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -125,7 +125,7 @@ Plans:
 | 12. Clipboard Monitoring | v0.4.0 | 2/2 | Complete | 2026-04-04 |
 | 13. Translation Download UI | v0.4.0 | 1/1 | Complete | 2026-04-04 |
 | 14. Shimmer Animation | v0.5.0 | 2/2 | Complete    | 2026-04-12 |
-| 15. Chunked Translation | v0.5.0 | 2/2 | Complete   | 2026-04-12 |
+| 15. Chunked Translation | v0.5.0 | 2/2 | Complete    | 2026-04-12 |
 | 16. Pivot Translation | v0.5.0 | 0/2 | Not started | — |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -89,7 +89,11 @@ Plans:
   1. A text of 201+ characters is split into sentence-boundary chunks via `NLTokenizer` and all chunks are submitted as one `translations(from:)` batch call
   2. The translated chunks are recombined in input order — the result reads as continuous prose regardless of chunk count
   3. A text of ≤200 characters is translated directly without any chunking (single-call path, no overhead)
-**Plans**: TBD (estimated 2 plans)
+**Plans**: 2 plans
+
+Plans:
+- [ ] 15-01-PLAN.md — TextChunker TDD: sentence-boundary chunking with separator recording
+- [ ] 15-02-PLAN.md — Wire chunked batch translation into PopupView
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Translation Quality
-status: Ready to plan
+status: "Phase 15 shipped — PR #34"
 stopped_at: Completed 14-02-PLAN.md
-last_updated: "2026-04-12T14:11:56.132Z"
+last_updated: "2026-04-16T16:02:18.575Z"
 progress:
   total_phases: 3
   completed_phases: 2

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Translation Quality
-status: Executing Phase 15
+status: Ready to plan
 stopped_at: Completed 14-02-PLAN.md
-last_updated: "2026-04-12T14:04:18.042Z"
+last_updated: "2026-04-12T14:11:56.132Z"
 progress:
   total_phases: 3
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 4
-  completed_plans: 2
+  completed_plans: 4
 ---
 
 # Project State
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-04-12)
 
 ## Current Position
 
-Phase: 15 (chunked-translation) — EXECUTING
-Plan: 1 of 2
+Phase: 16
+Plan: Not started
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Translation Quality
-status: "Phase 15 shipped — PR #34"
-stopped_at: Completed 14-02-PLAN.md
-last_updated: "2026-04-16T16:02:18.575Z"
+status: "Phase 15 shipped — PR #34, awaiting merge"
+stopped_at: "Phase 15 shipped — PR #34"
+last_updated: "2026-04-17T01:40:00.000Z"
 progress:
   total_phases: 3
   completed_phases: 2
-  total_plans: 4
-  completed_plans: 4
+  total_plans: 5
+  completed_plans: 5
 ---
 
 # Project State
@@ -19,7 +19,7 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-12)
 
 **Core value:** Selected text turns into a natural translation almost instantly without breaking the user's reading flow.
-**Current focus:** Phase 15 — chunked-translation
+**Current focus:** Phase 15 shipped (PR #34) — next: Phase 16 pivot-translation
 
 ## Current Position
 
@@ -81,6 +81,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-12T12:55:00.512Z
-Stopped at: Completed 14-02-PLAN.md
+Last session: 2026-04-17T01:40:00.000Z
+Stopped at: Phase 15 shipped — PR #34
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Translation Quality
-status: "Phase 14 shipped — PR #33"
+status: Executing Phase 15
 stopped_at: Completed 14-02-PLAN.md
-last_updated: "2026-04-12T12:55:00.512Z"
+last_updated: "2026-04-12T14:04:18.042Z"
 progress:
   total_phases: 3
   completed_phases: 1
-  total_plans: 2
+  total_plans: 4
   completed_plans: 2
 ---
 
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-04-12)
 
 ## Current Position
 
-Phase: 15
-Plan: Not started
+Phase: 15 (chunked-translation) — EXECUTING
+Plan: 1 of 2
 
 ## Performance Metrics
 

--- a/.planning/phases/15-chunked-translation/15-01-PLAN.md
+++ b/.planning/phases/15-chunked-translation/15-01-PLAN.md
@@ -1,0 +1,274 @@
+---
+phase: 15-chunked-translation
+plan: 01
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - Transy/Translation/TextChunker.swift
+  - TransyTests/TextChunkerTests.swift
+  - Transy.xcodeproj/project.pbxproj
+autonomous: true
+requirements: [CHK-01, CHK-03]
+
+must_haves:
+  truths:
+    - "Text of 200 characters or fewer returns a single ChunkedSegment without invoking NLTokenizer"
+    - "Text over 200 characters is split at NLTokenizer sentence boundaries into multiple ChunkedSegment values"
+    - "Sentences are grouped greedily so each chunk stays within the threshold"
+    - "Original whitespace/newlines between chunk boundaries are preserved as separator strings"
+    - "Empty or whitespace-only sentence ranges are filtered from the output"
+    - "Reconstructing chunks + separators reproduces the original input text exactly"
+  artifacts:
+    - path: "Transy/Translation/TextChunker.swift"
+      provides: "enum TextChunker with ChunkedSegment struct and chunk(text:threshold:) static method"
+      contains: "enum TextChunker"
+    - path: "TransyTests/TextChunkerTests.swift"
+      provides: "Unit tests for TextChunker behavior"
+      contains: "@Test"
+  key_links:
+    - from: "Transy/Translation/TextChunker.swift"
+      to: "NLTokenizer(unit: .sentence)"
+      via: "sentence tokenization for text > threshold"
+      pattern: "NLTokenizer\\(unit: \\.sentence\\)"
+---
+
+<objective>
+Create TextChunker enum namespace with TDD: sentence-boundary text splitting with separator recording.
+
+Purpose: CHK-01 requires NLTokenizer sentence splitting for long text. CHK-03 requires short-text bypass. TextChunker is a pure-logic module with clear I/O — ideal for TDD.
+Output: `Transy/Translation/TextChunker.swift` + `TransyTests/TextChunkerTests.swift`, all tests green.
+</objective>
+
+<execution_context>
+@.github/get-shit-done/workflows/execute-plan.md
+@.github/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/15-chunked-translation/15-CONTEXT.md
+@.planning/research/PITFALLS.md (Pitfalls 5, 8)
+@Transy/Translation/TextNormalization.swift (enum namespace pattern to follow)
+@TransyTests/ShimmerModifierTests.swift (test structure pattern)
+
+<interfaces>
+<!-- Existing enum namespace pattern from TextNormalization.swift -->
+From Transy/Translation/TextNormalization.swift:
+```swift
+import Foundation
+
+enum TextNormalization {
+    static func normalized(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func detectionSample(from text: String) -> String {
+        normalized(text)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+}
+```
+
+<!-- Test file pattern from ShimmerModifierTests.swift -->
+From TransyTests/ShimmerModifierTests.swift:
+```swift
+import SwiftUI
+import Testing
+@testable import Transy
+
+struct ShimmerModifierTests {
+    @Test("shimmer() extension returns a ModifiedContent view")
+    @MainActor
+    func shimmerExtensionReturnsModifiedContent() {
+        let result = Text("Test").shimmer()
+        let typeName = String(describing: type(of: result))
+        #expect(typeName.contains("ModifiedContent"), "shimmer() should wrap content in ModifiedContent")
+    }
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: RED — Create TextChunker stub + full test suite</name>
+  <files>Transy/Translation/TextChunker.swift, TransyTests/TextChunkerTests.swift</files>
+  <read_first>
+    - Transy/Translation/TextNormalization.swift (enum namespace pattern to replicate)
+    - TransyTests/ShimmerModifierTests.swift (test file structure: imports, @Test annotations, @testable import)
+    - .planning/phases/15-chunked-translation/15-CONTEXT.md (locked decisions: separator recording, ChunkedSegment return type, threshold 200)
+  </read_first>
+  <behavior>
+    - Test 1 "short text bypass": `TextChunker.chunk(text: "Hello world.", threshold: 200)` returns exactly 1 ChunkedSegment with chunk == "Hello world." and separator == ""
+    - Test 2 "exactly at threshold": `TextChunker.chunk(text: String(repeating: "a", count: 200), threshold: 200)` returns 1 segment (no split)
+    - Test 3 "splits at sentence boundaries": Text with 3 short sentences and threshold low enough to force splitting returns count > 1, each chunk is non-empty
+    - Test 4 "roundtrip invariant": For any chunked result, `segments.map { $0.chunk + $0.separator }.joined()` equals the original input text
+    - Test 5 "paragraph breaks preserved": Text with `\n\n` between paragraphs — roundtrip invariant holds and reconstructed text contains "\n\n"
+    - Test 6 "no whitespace-only chunks": Text with consecutive newlines — every segment.chunk.trimmingCharacters(in: .whitespacesAndNewlines) is non-empty (Pitfall 8)
+    - Test 7 "default threshold is 200": Calling `TextChunker.chunk(text:)` without threshold parameter compiles and uses 200
+    - Test 8 "single sentence over threshold": A single sentence >200 chars returns exactly 1 segment (no sub-splitting)
+    - Test 9 "sentences grouped within threshold": Multiple short sentences totalling under threshold returns 1 segment
+  </behavior>
+  <action>
+    **Step 1 — Create TextChunker.swift with compilable stub** (per CONTEXT.md: enum namespace, `TextChunker.chunk(text:threshold:) -> [ChunkedSegment]`):
+
+    ```swift
+    import NaturalLanguage
+
+    enum TextChunker {
+        struct ChunkedSegment: Sendable, Equatable {
+            let chunk: String
+            let separator: String
+        }
+
+        static func chunk(
+            text: String,
+            threshold: Int = 200
+        ) -> [ChunkedSegment] {
+            // Stub: return empty to make tests fail (RED)
+            []
+        }
+    }
+    ```
+
+    **Step 2 — Create TextChunkerTests.swift** with all 9 tests from the behavior block above. Use Swift Testing framework (`import Testing`, `@testable import Transy`, `@Test("description")`, `#expect()`). Do NOT use XCTest.
+
+    Test data guidelines:
+    - For "splits at sentence boundaries" (Test 3): Use natural English sentences like `"The quick brown fox jumped. The lazy dog slept. The cat watched."` with a low threshold (e.g., 30) to force splitting.
+    - For "roundtrip invariant" (Test 4): Use multi-paragraph text with `\n` and spaces between sentences. Assert `result.map { $0.chunk + $0.separator }.joined() == text`.
+    - For "paragraph breaks preserved" (Test 5): Use `"First paragraph.\n\nSecond paragraph."` with threshold 20.
+    - For "no whitespace-only chunks" (Test 6): Use `"Line one.\n\n\nLine two."` with threshold 15.
+    - For "single sentence over threshold" (Test 8): Use a single sentence >200 chars (e.g., `String(repeating: "word ", count: 50) + "end."`) with default threshold.
+    - For "sentences grouped" (Test 9): Use `"Short. Also short. Tiny."` with threshold 200.
+
+    **Step 3 — Regenerate Xcode project and run tests:**
+    ```bash
+    make generate
+    xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests/TextChunkerTests -quiet
+    ```
+    Tests MUST compile. Tests MUST fail (RED confirmed). At least 8 of 9 tests should fail (the default-threshold test might pass vacuously depending on stub).
+
+    Commit: `test(15-01): add failing TextChunker tests`
+  </action>
+  <verify>
+    <automated>cd /Users/tafuru/repos/github.com/tafuru/transy && make generate && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests/TextChunkerTests 2>&1 | tail -20</automated>
+    Tests must compile but the majority must FAIL (RED state). Verify with: `grep -c "@Test" TransyTests/TextChunkerTests.swift` returns at least 9.
+  </verify>
+  <acceptance_criteria>
+    - `grep -q "enum TextChunker" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "struct ChunkedSegment: Sendable, Equatable" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "static func chunk(text:" Transy/Translation/TextChunker.swift` succeeds (note: line may wrap — grep for start of signature)
+    - `grep -q "threshold: Int = 200" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "import NaturalLanguage" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "@testable import Transy" TransyTests/TextChunkerTests.swift` succeeds
+    - `grep -c "@Test" TransyTests/TextChunkerTests.swift` returns 9 or more
+    - `grep -q "TextChunker.chunk(text:" TransyTests/TextChunkerTests.swift` succeeds
+    - `grep -q "roundtrip" TransyTests/TextChunkerTests.swift` succeeds (roundtrip invariant test exists)
+    - Build succeeds: `make generate && make build` exits 0
+    - Tests compile and mostly FAIL (RED): xcodebuild test output shows test failures
+  </acceptance_criteria>
+  <done>TextChunker stub compiles, full test suite exists with 9+ tests, RED state confirmed (tests fail against stub)</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: GREEN — Implement TextChunker to pass all tests</name>
+  <files>Transy/Translation/TextChunker.swift</files>
+  <read_first>
+    - TransyTests/TextChunkerTests.swift (the tests that must pass — read FIRST to understand expected behavior)
+    - Transy/Translation/TextChunker.swift (current stub to replace)
+    - .planning/phases/15-chunked-translation/15-CONTEXT.md (separator recording design, NLTokenizer .sentence, empty chunk filtering)
+    - .planning/research/PITFALLS.md lines 153-161 (Pitfall 8: empty/whitespace chunk filtering)
+  </read_first>
+  <action>
+    Replace the stub body of `TextChunker.chunk(text:threshold:)` with the full implementation. Follow this algorithm exactly:
+
+    **Short-text bypass (CHK-03):**
+    ```swift
+    guard text.count > threshold else {
+        return [ChunkedSegment(chunk: text, separator: "")]
+    }
+    ```
+
+    **NLTokenizer sentence enumeration:**
+    ```swift
+    let tokenizer = NLTokenizer(unit: .sentence)
+    tokenizer.string = text
+
+    var sentenceRanges: [Range<String.Index>] = []
+    tokenizer.enumerateTokens(
+        in: text.startIndex..<text.endIndex
+    ) { range, _ in
+        sentenceRanges.append(range)
+        return true
+    }
+
+    guard !sentenceRanges.isEmpty else {
+        return [ChunkedSegment(chunk: text, separator: "")]
+    }
+    ```
+
+    **Greedy sentence grouping into chunks ≤ threshold:**
+    Group sentence ranges so the text span from the first sentence's `lowerBound` to the last sentence's `upperBound` in each group stays ≤ `threshold` characters. If a single sentence exceeds `threshold`, it becomes its own chunk (no sub-splitting). Use `text.distance(from:to:)` for character counting (not byte counting).
+
+    **Separator extraction:**
+    For each group, the chunk text = `String(text[groupFirstSentence.lowerBound..<groupLastSentence.upperBound])`.
+    The separator = `String(text[groupLastSentence.upperBound..<nextGroupFirstSentence.lowerBound])` (the gap between this group's end and the next group's start).
+    For the last group, separator = `String(text[groupLastSentence.upperBound..<text.endIndex])` (any trailing text after the last sentence).
+
+    **Empty chunk filtering (Pitfall 8):**
+    Skip any chunk where `chunk.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty`.
+
+    **Fallback:** If after filtering all chunks are empty, return `[ChunkedSegment(chunk: text, separator: "")]`.
+
+    **Critical invariant:** `segments.map { $0.chunk + $0.separator }.joined() == text` must hold for all inputs.
+
+    After implementation, run:
+    ```bash
+    xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests/TextChunkerTests -quiet
+    ```
+    ALL tests must pass (GREEN).
+
+    If any test fails, read the failure output, adjust implementation, and re-run until GREEN.
+
+    Commit: `feat(15-01): implement TextChunker sentence-boundary chunking`
+  </action>
+  <verify>
+    <automated>cd /Users/tafuru/repos/github.com/tafuru/transy && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests/TextChunkerTests -quiet 2>&1 | tail -5</automated>
+    Output must show "Test Suite 'All tests' passed" or all TextChunkerTests tests passed. Zero failures.
+  </verify>
+  <acceptance_criteria>
+    - `grep -q "NLTokenizer(unit: .sentence)" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "enumerateTokens" Transy/Translation/TextChunker.swift` succeeds
+    - `grep -q "trimmingCharacters(in: .whitespacesAndNewlines).isEmpty" Transy/Translation/TextChunker.swift` succeeds (Pitfall 8 filter)
+    - `grep -q "text.count > threshold" Transy/Translation/TextChunker.swift` succeeds (short-text guard)
+    - xcodebuild test for TextChunkerTests exits 0 (all tests GREEN)
+    - Full test suite still passes: `xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet` exits 0
+  </acceptance_criteria>
+  <done>All TextChunkerTests pass (GREEN). TextChunker splits text >200 chars at sentence boundaries via NLTokenizer, groups sentences into ≤threshold chunks, records separators, filters empty chunks. Text ≤200 chars returns single segment without NLTokenizer. Full TransyTests suite passes.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `Transy/Translation/TextChunker.swift` exists with `enum TextChunker`, `struct ChunkedSegment`, `static func chunk(text:threshold:)`
+2. `TransyTests/TextChunkerTests.swift` exists with 9+ `@Test` functions
+3. `make generate && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet` passes — all tests GREEN
+4. Roundtrip invariant holds: chunks + separators reconstruct original text
+</verification>
+
+<success_criteria>
+- TextChunker.chunk(text: shortText) returns single segment (CHK-03 short-text bypass, no NLTokenizer)
+- TextChunker.chunk(text: longText) returns multiple segments split at sentence boundaries (CHK-01)
+- All 9+ tests pass GREEN
+- Empty/whitespace chunks filtered (Pitfall 8)
+- Full TransyTests suite passes (no regressions)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/15-chunked-translation/15-01-SUMMARY.md`
+</output>

--- a/.planning/phases/15-chunked-translation/15-01-SUMMARY.md
+++ b/.planning/phases/15-chunked-translation/15-01-SUMMARY.md
@@ -1,0 +1,83 @@
+---
+phase: 15-chunked-translation
+plan: 01
+subsystem: translation
+tags: [NLTokenizer, sentence-splitting, text-processing]
+
+requires: []
+provides:
+  - "TextChunker.chunk(text:threshold:) → [ChunkedSegment] API for sentence-boundary splitting"
+  - "Roundtrip-safe separator recording between chunks"
+affects: [15-02, translation-pipeline]
+
+tech-stack:
+  added: []
+  patterns: ["enum namespace with static methods (matches TextNormalization)"]
+
+key-files:
+  created:
+    - Transy/Translation/TextChunker.swift
+    - TransyTests/TextChunkerTests.swift
+  modified: []
+
+key-decisions:
+  - "Greedy sentence grouping: pack as many sentences as fit within threshold"
+  - "Separator = gap between NLTokenizer ranges, not hardcoded delimiter"
+
+patterns-established:
+  - "TDD cycle: stub → 9 failing tests → implement → all GREEN"
+  - "ChunkedSegment(chunk:separator:) as data contract for chunked translation"
+
+requirements-completed: [CHK-01, CHK-03]
+
+duration: 5min
+completed: 2026-04-12
+---
+
+# Plan 15-01: TextChunker TDD Summary
+
+**NLTokenizer sentence-boundary splitter with greedy grouping, separator recording, and 9-test TDD suite**
+
+## Performance
+
+- **Duration:** ~5 min
+- **Started:** 2026-04-12T22:56:00Z
+- **Completed:** 2026-04-12T23:06:00Z
+- **Tasks:** 2 (RED → GREEN)
+- **Files modified:** 3
+
+## Accomplishments
+- TextChunker enum namespace with `chunk(text:threshold:)` static method
+- Short-text bypass (≤200 chars) skips NLTokenizer entirely (CHK-03)
+- Sentence-boundary splitting via NLTokenizer `.sentence` unit (CHK-01)
+- Greedy grouping keeps chunks within threshold
+- Separator recording preserves original whitespace/newlines between chunks
+- Empty/whitespace-only chunk filtering (Pitfall 8)
+- Roundtrip invariant: `chunks + separators == original text`
+- 9 comprehensive tests all passing
+
+## Task Commits
+
+1. **Task 1: RED — TextChunker stub + test suite** - `4fbb431` (test)
+2. **Task 2: GREEN — Full implementation** - `ff7f23f` (feat)
+
+## Files Created/Modified
+- `Transy/Translation/TextChunker.swift` — enum namespace with ChunkedSegment struct and chunk() method
+- `TransyTests/TextChunkerTests.swift` — 9 tests covering all edge cases
+
+## Decisions Made
+None — followed plan as specified.
+
+## Deviations from Plan
+None — plan executed exactly as written.
+
+## Issues Encountered
+None.
+
+## Next Phase Readiness
+- TextChunker API ready for Plan 15-02 to wire into PopupView
+- `[ChunkedSegment]` is Sendable — safe for nonisolated closure capture
+
+---
+*Phase: 15-chunked-translation*
+*Completed: 2026-04-12*

--- a/.planning/phases/15-chunked-translation/15-02-PLAN.md
+++ b/.planning/phases/15-chunked-translation/15-02-PLAN.md
@@ -275,7 +275,7 @@ struct Response {
     - `grep -q "segments.count <= 1" Transy/Popup/PopupView.swift` succeeds (single-chunk bypass condition)
     - `grep -q "zip(responses, segments)" Transy/Popup/PopupView.swift` succeeds (ordered recombination with separators)
     - `grep -q "session.translate(" Transy/Popup/PopupView.swift` succeeds (single-chunk path still uses direct translate)
-    - `grep -qv "translate(batch:" Transy/Popup/PopupView.swift` — the wrong API `translate(batch:)` does NOT appear
+    - `! grep -q "translate(batch:" Transy/Popup/PopupView.swift` — the wrong API `translate(batch:)` does NOT appear
     - `make build` exits 0 (no compile errors, no Swift 6 concurrency errors)
     - `xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet` exits 0 (all tests pass)
   </acceptance_criteria>

--- a/.planning/phases/15-chunked-translation/15-02-PLAN.md
+++ b/.planning/phases/15-chunked-translation/15-02-PLAN.md
@@ -1,0 +1,305 @@
+---
+phase: 15-chunked-translation
+plan: 02
+type: execute
+wave: 2
+depends_on: ["15-01"]
+files_modified:
+  - Transy/Popup/PopupView.swift
+autonomous: true
+requirements: [CHK-02]
+
+must_haves:
+  truths:
+    - "Multiple chunks are submitted as a single batch call via session.translations(from:)"
+    - "Translated chunks are recombined with original separators in input order"
+    - "Single-chunk text (≤200 chars) uses session.translate() directly — zero batch overhead"
+    - "TextChunker.chunk() runs on MainActor in body before translationAction closure (Pitfall 5)"
+  artifacts:
+    - path: "Transy/Popup/PopupView.swift"
+      provides: "Modified LoadingPopupText with chunked batch translation path"
+      contains: "translations(from:"
+  key_links:
+    - from: "LoadingPopupText.body"
+      to: "TextChunker.chunk(text:"
+      via: "synchronous call on MainActor before closure creation"
+      pattern: "TextChunker\\.chunk\\(text:"
+    - from: "translationAction closure"
+      to: "session.translations(from: requests)"
+      via: "batch API for multi-chunk translation"
+      pattern: "session\\.translations\\(from:"
+    - from: "translationAction closure"
+      to: "onResult"
+      via: "zip(responses, segments) joined with separators"
+      pattern: "zip\\(responses"
+---
+
+<objective>
+Wire TextChunker into LoadingPopupText's translation action to use the batch API for chunked text.
+
+Purpose: CHK-02 requires batch `translations(from:)` and correctly ordered recombination. This plan modifies the single integration point — PopupView.swift.
+Output: Modified `Transy/Popup/PopupView.swift` where long text is chunked on MainActor and translated via batch API.
+</objective>
+
+<execution_context>
+@.github/get-shit-done/workflows/execute-plan.md
+@.github/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/15-chunked-translation/15-CONTEXT.md
+@.planning/phases/15-chunked-translation/15-01-SUMMARY.md
+@.planning/research/PITFALLS.md (Pitfalls 4, 5)
+@.planning/research/ARCHITECTURE.md (batch API pattern, lines 181-196)
+
+<interfaces>
+<!-- TextChunker API created in Plan 01 -->
+From Transy/Translation/TextChunker.swift:
+```swift
+import NaturalLanguage
+
+enum TextChunker {
+    struct ChunkedSegment: Sendable, Equatable {
+        let chunk: String
+        let separator: String
+    }
+
+    /// Splits text at sentence boundaries into chunks of ≤ threshold characters.
+    /// Text at or below threshold returns a single segment (no NLTokenizer).
+    static func chunk(
+        text: String,
+        threshold: Int = 200
+    ) -> [ChunkedSegment]
+}
+```
+
+<!-- Current LoadingPopupText to be modified -->
+From Transy/Popup/PopupView.swift (LoadingPopupText, lines 105-160):
+```swift
+private struct LoadingPopupText: View {
+    let requestContext: LoadingRequestContext
+    let targetLanguage: Locale.Language
+    let onResult: @Sendable (UUID, String, String) async -> Void
+    let onError: @Sendable (UUID, String, String) async -> Void
+    @State private var translationConfiguration: TranslationSession.Configuration?
+
+    var body: some View {
+        let requestContext = requestContext
+        let targetLanguage = targetLanguage
+        let onResult = onResult
+        let onError = onError
+
+        return PopupText(text: requestContext.sourceText, isMuted: true)
+            .shimmer()
+            .onChange(of: requestContext.requestID, initial: true) { _, _ in
+                translationConfiguration = nextTranslationConfiguration(
+                    after: translationConfiguration,
+                    targetLanguage: targetLanguage
+                )
+            }
+            .translationTask(
+                translationConfiguration,
+                action: Self.translationAction(
+                    requestContext: requestContext,
+                    onResult: onResult,
+                    onError: onError
+                )
+            )
+    }
+
+    nonisolated private static func translationAction(
+        requestContext: LoadingRequestContext,
+        onResult: @escaping @Sendable (UUID, String, String) async -> Void,
+        onError: @escaping @Sendable (UUID, String, String) async -> Void
+    ) -> (TranslationSession) async -> Void {
+        { session in
+            do {
+                let response = try await session.translate(requestContext.sourceText)
+                await onResult(
+                    requestContext.requestID,
+                    requestContext.sourceText,
+                    response.targetText
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                await onError(
+                    requestContext.requestID,
+                    requestContext.sourceText,
+                    TranslationErrorMapper.message(for: error)
+                )
+            }
+        }
+    }
+}
+```
+
+<!-- TranslationSession batch API signature (Apple framework) -->
+```swift
+// TranslationSession (Apple Translation framework)
+func translations(from batch: [TranslationSession.Request]) async throws -> [TranslationSession.Response]
+// Response array is in the SAME ORDER as input Request array — no clientIdentifier reordering needed.
+
+struct Request {
+    init(sourceText: String, clientIdentifier: String? = nil)
+}
+struct Response {
+    var targetText: String
+    var clientIdentifier: String?
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Wire TextChunker + batch API into LoadingPopupText</name>
+  <files>Transy/Popup/PopupView.swift</files>
+  <read_first>
+    - Transy/Popup/PopupView.swift (full file — understand current LoadingPopupText.body and translationAction)
+    - Transy/Translation/TextChunker.swift (API: TextChunker.chunk(text:threshold:) -> [ChunkedSegment])
+    - .planning/phases/15-chunked-translation/15-CONTEXT.md (NLTokenizer isolation: chunk in body before closure; batch API choice; error handling: fail entire translation)
+    - .planning/research/PITFALLS.md lines 77-93 (Pitfall 4: use translations(from:), NOT sequential translate() or translate(batch:))
+    - .planning/research/PITFALLS.md lines 97-117 (Pitfall 5: NLTokenizer on MainActor, not in nonisolated context)
+  </read_first>
+  <action>
+    Modify `LoadingPopupText` in `Transy/Popup/PopupView.swift`. Two changes: body and translationAction.
+
+    **Change 1 — In `body`, compute segments on MainActor before closure creation (Pitfall 5):**
+
+    Add this line after the existing `let onError = onError` line and before the `return PopupText(...)` line:
+
+    ```swift
+    let segments = TextChunker.chunk(text: requestContext.sourceText)
+    ```
+
+    Then update the `.translationTask` action call to pass `segments`:
+
+    ```swift
+    .translationTask(
+        translationConfiguration,
+        action: Self.translationAction(
+            requestContext: requestContext,
+            segments: segments,
+            onResult: onResult,
+            onError: onError
+        )
+    )
+    ```
+
+    **Change 2 — Modify `translationAction` to accept segments and use batch API:**
+
+    Replace the entire `translationAction` method with:
+
+    ```swift
+    nonisolated private static func translationAction(
+        requestContext: LoadingRequestContext,
+        segments: [TextChunker.ChunkedSegment],
+        onResult: @escaping @Sendable (UUID, String, String) async -> Void,
+        onError: @escaping @Sendable (UUID, String, String) async -> Void
+    ) -> (TranslationSession) async -> Void {
+        { session in
+            do {
+                let translatedText: String
+
+                if segments.count <= 1 {
+                    // CHK-03: single chunk — translate directly, zero batch overhead
+                    let response = try await session.translate(
+                        segments.first?.chunk ?? requestContext.sourceText
+                    )
+                    translatedText = response.targetText
+                } else {
+                    // CHK-02: multiple chunks — batch API, results in input order
+                    let requests = segments.map { segment in
+                        TranslationSession.Request(sourceText: segment.chunk)
+                    }
+                    let responses = try await session.translations(from: requests)
+                    translatedText = zip(responses, segments)
+                        .map { response, segment in
+                            response.targetText + segment.separator
+                        }
+                        .joined()
+                }
+
+                await onResult(
+                    requestContext.requestID,
+                    requestContext.sourceText,
+                    translatedText
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                await onError(
+                    requestContext.requestID,
+                    requestContext.sourceText,
+                    TranslationErrorMapper.message(for: error)
+                )
+            }
+        }
+    }
+    ```
+
+    **Key design points:**
+    - `TextChunker.chunk()` is called synchronously in `body` (on MainActor) — NLTokenizer never enters the nonisolated closure (Pitfall 5 ✓)
+    - `[TextChunker.ChunkedSegment]` is `Sendable` (struct of two Strings) — safe to capture in nonisolated closure
+    - Single chunk path uses `session.translate()` — zero overhead for short text (CHK-03 ✓)
+    - Multi-chunk path uses `session.translations(from:)` — single batch call, NOT sequential translate() loops (Pitfall 4 ✓)
+    - `zip(responses, segments).map { $0.targetText + $1.separator }.joined()` preserves original separators in input order (CHK-02 ✓)
+    - Error handling unchanged: any error fails entire translation, caught and mapped by TranslationErrorMapper (per CONTEXT.md)
+
+    **Do NOT:**
+    - Use `translate(batch:)` (AsyncThrowingStream, unordered — wrong API per Pitfall 4)
+    - Use a `for chunk in chunks { try await session.translate(chunk) }` loop (N× latency — Pitfall 4)
+    - Create NLTokenizer inside translationAction (Pitfall 5 — Swift 6 concurrency error)
+    - Add `import NaturalLanguage` to PopupView.swift (not needed — TextChunker handles it internally)
+
+    After editing, verify build and existing tests:
+    ```bash
+    make build && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet
+    ```
+
+    Commit: `feat(15-02): wire chunked batch translation into PopupView`
+  </action>
+  <verify>
+    <automated>cd /Users/tafuru/repos/github.com/tafuru/transy && make build 2>&1 | tail -5 && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet 2>&1 | tail -5</automated>
+    Build succeeds (exit 0). All existing TransyTests pass (no regressions). Zero Swift 6 concurrency warnings related to TextChunker or NLTokenizer.
+  </verify>
+  <acceptance_criteria>
+    - `grep -q "TextChunker.chunk(text: requestContext.sourceText)" Transy/Popup/PopupView.swift` succeeds (chunking on MainActor in body)
+    - `grep -q "segments: \[TextChunker.ChunkedSegment\]" Transy/Popup/PopupView.swift` succeeds (segments parameter in translationAction signature)
+    - `grep -q "session.translations(from: requests)" Transy/Popup/PopupView.swift` succeeds (batch API call)
+    - `grep -q "segments.count <= 1" Transy/Popup/PopupView.swift` succeeds (single-chunk bypass condition)
+    - `grep -q "zip(responses, segments)" Transy/Popup/PopupView.swift` succeeds (ordered recombination with separators)
+    - `grep -q "session.translate(" Transy/Popup/PopupView.swift` succeeds (single-chunk path still uses direct translate)
+    - `grep -qv "translate(batch:" Transy/Popup/PopupView.swift` — the wrong API `translate(batch:)` does NOT appear
+    - `make build` exits 0 (no compile errors, no Swift 6 concurrency errors)
+    - `xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet` exits 0 (all tests pass)
+  </acceptance_criteria>
+  <done>LoadingPopupText chunks text on MainActor before closure, translationAction uses batch translations(from:) for multi-chunk text and session.translate() for single chunk, results joined with original separators in order. Build passes, all tests pass, no Swift 6 concurrency issues.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `grep "TextChunker.chunk" Transy/Popup/PopupView.swift` shows chunking call in body
+2. `grep "translations(from:" Transy/Popup/PopupView.swift` shows batch API usage
+3. `grep "segments.count <= 1" Transy/Popup/PopupView.swift` shows short-text bypass
+4. `make build` exits 0 — compiles with Swift 6 strict concurrency
+5. `xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet` exits 0 — all tests pass including TextChunkerTests from Plan 01
+</verification>
+
+<success_criteria>
+- Text >200 chars: chunked on MainActor, translated via single batch translations(from:) call, recombined with separators in order (CHK-02)
+- Text ≤200 chars: session.translate() directly, no batch API overhead
+- No NLTokenizer usage inside translationAction closure (Pitfall 5 avoided)
+- No sequential translate() loop (Pitfall 4 avoided)
+- Build and all tests pass with Swift 6 strict concurrency
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/15-chunked-translation/15-02-SUMMARY.md`
+</output>

--- a/.planning/phases/15-chunked-translation/15-02-SUMMARY.md
+++ b/.planning/phases/15-chunked-translation/15-02-SUMMARY.md
@@ -1,0 +1,78 @@
+---
+phase: 15-chunked-translation
+plan: 02
+subsystem: translation
+tags: [batch-api, TranslationSession, PopupView]
+
+requires:
+  - phase: 15-01
+    provides: "TextChunker.chunk(text:threshold:) → [ChunkedSegment]"
+provides:
+  - "Chunked batch translation in LoadingPopupText via translations(from:)"
+  - "Single-chunk bypass with session.translate() for short text"
+affects: [translation-pipeline, popup]
+
+tech-stack:
+  added: []
+  patterns: ["MainActor chunking before nonisolated closure", "batch API with ordered recombination"]
+
+key-files:
+  created: []
+  modified:
+    - Transy/Popup/PopupView.swift
+
+key-decisions:
+  - "TextChunker.chunk() in body (MainActor) — NLTokenizer never enters nonisolated closure"
+  - "segments.count <= 1 guard for single-chunk bypass"
+
+patterns-established:
+  - "zip(responses, segments) for ordered recombination with separators"
+
+requirements-completed: [CHK-02]
+
+duration: 3min
+completed: 2026-04-12
+---
+
+# Plan 15-02: Wire Batch Translation Summary
+
+**Batch translations(from:) API wired into PopupView with MainActor-safe chunking and separator-preserving recombination**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-04-12T23:06:00Z
+- **Completed:** 2026-04-12T23:09:00Z
+- **Tasks:** 1
+- **Files modified:** 1
+
+## Accomplishments
+- TextChunker.chunk() called on MainActor in body before closure (Pitfall 5)
+- Multi-chunk text translated via single batch translations(from:) call (Pitfall 4)
+- Single-chunk text uses session.translate() directly — zero overhead (CHK-03)
+- Results recombined with original separators via zip() (CHK-02)
+- Build and all tests pass with Swift 6 strict concurrency
+
+## Task Commits
+
+1. **Task 1: Wire TextChunker + batch API** - `a339bf8` (feat)
+
+## Files Created/Modified
+- `Transy/Popup/PopupView.swift` — Modified LoadingPopupText.body and translationAction
+
+## Decisions Made
+None — followed plan as specified.
+
+## Deviations from Plan
+None — plan executed exactly as written.
+
+## Issues Encountered
+None.
+
+## Next Phase Readiness
+- Chunked translation fully wired — ready for verification
+- Phase 16 (Pivot Translation) can build on this foundation
+
+---
+*Phase: 15-chunked-translation*
+*Completed: 2026-04-12*

--- a/.planning/phases/15-chunked-translation/15-CONTEXT.md
+++ b/.planning/phases/15-chunked-translation/15-CONTEXT.md
@@ -1,0 +1,70 @@
+# Phase 15: Chunked Translation — Context
+
+## Domain Boundary
+
+Texts longer than 200 characters are split at sentence boundaries via NLTokenizer and translated as a single batch call, returning a correctly ordered result. Texts ≤200 characters bypass chunking entirely.
+
+## Decisions
+
+### Chunking Threshold
+- **200 characters fixed** — no dynamic adjustment
+- NLTokenizer `.sentence` unit for boundary detection
+- Sentences are grouped into chunks of ≤200 characters each (chunk = multiple sentences)
+- This reduces the number of batch requests compared to one-request-per-sentence
+
+### Short-Text Bypass (CHK-03)
+- **NLTokenizer is completely skipped** for ≤200 char texts
+- Character count check only, then `session.translate()` directly (current code path unchanged)
+- Zero overhead for short texts
+
+### Batch API Choice
+- **`translations(from: [TranslationSession.Request])`** — returns `[Response]` in input order
+- NOT `translate(batch:)` (AsyncThrowingStream, unordered) — per Pitfall 4
+- All chunks submitted as one batch call, results returned all at once
+
+### Error Handling
+- **Fail entire translation on any error** — no partial results
+- The batch API is all-or-nothing, so this aligns naturally
+- Existing `TranslationErrorMapper` handles the error display
+
+### Whitespace & Separator Preservation
+- **Separator recording approach** — record original text between chunk boundaries
+- NLTokenizer returns `Range<String.Index>` — gaps between ranges are the separators
+- TextChunker returns `[(chunk: String, separator: String)]` structure
+- Joining: interleave translated chunks with original separators
+- Preserves newlines, paragraph breaks, and indentation from source text
+
+### Shimmer Integration
+- **Shimmer stays as-is** — covers entire source text during loading
+- No progressive display (translations(from:) returns all results at once)
+- Shimmer stops when full translated result appears — same UX as current single-call path
+
+### Code Placement
+- **New file: `Transy/Translation/TextChunker.swift`** — enum namespace
+- Separate from TextNormalization (different responsibility: NLTokenizer vs simple string ops)
+- API: `TextChunker.chunk(text:threshold:) -> [ChunkedSegment]`
+- Tests: `TransyTests/TextChunkerTests.swift`
+
+### NLTokenizer Isolation (Pitfall 5)
+- NLTokenizer must run on `@MainActor` (non-Sendable ObjC class in Swift 6)
+- Chunking performed in `LoadingPopupText` (already on MainActor) BEFORE `translationAction` closure
+- Chunk array (`[String]`, Sendable) captured in closure safely
+
+## Specifics
+
+- User explicitly chose separator recording over block-then-sentence splitting
+- User confirmed that progressive streaming display is deferred (considered translate(batch:) but chose simplicity)
+- User wants new file rather than expanding TextNormalization
+
+## Deferred Ideas
+
+- Progressive chunk display with `translate(batch:)` streaming — revisit in future milestone for richer UX
+
+## Canonical Refs
+
+- `.planning/research/PITFALLS.md` — Pitfalls 4, 5, 8 directly affect this phase
+- `.planning/research/ARCHITECTURE.md` — batch API usage patterns
+- `.planning/REQUIREMENTS.md` — CHK-01, CHK-02, CHK-03 definitions
+- `Transy/Popup/PopupView.swift` — `LoadingPopupText`, `translationAction` (integration points)
+- `Transy/Translation/TextNormalization.swift` — existing text processing pattern to follow
+- `Transy/Translation/TranslationCoordinator.swift` — state machine (no changes needed)

--- a/.planning/phases/15-chunked-translation/15-DISCUSSION-LOG.md
+++ b/.planning/phases/15-chunked-translation/15-DISCUSSION-LOG.md
@@ -1,0 +1,38 @@
+# Phase 15: Chunked Translation — Discussion Log
+
+**Date:** 2026-04-12
+**Participants:** User + AI
+
+## Gray Areas Discussed
+
+### 1. Chunking Threshold & Granularity
+- **Q:** 200文字の閾値設定について
+- **A:** 200文字固定でOK — 文境界で分割するので実際は各チャンクが200前後になる
+
+- **Q:** 文単位で個別リクエスト vs 200文字以下のチャンクにグループ化
+- **A:** 文をまとめて200文字以下のチャンクにグループ化 — リクエスト数を減らしてオーバーヘッド削減
+
+- **Q:** バッチ内の一部のチャンクが失敗した場合
+- **A:** 全体を失敗としてエラー表示 — シンプル、中途半端な結果より明確
+
+- **Q:** チャンクの結合時のセパレーター
+- **A:** 元のテキストの区切りを保持 — 改行やスペースをそのまま維持して結合
+
+### 2. Short-Text Bypass Behavior
+- **Q:** ≤200文字のテキストはNLTokenizerを通すか完全スキップか
+- **A:** NLTokenizerを完全スキップ — 文字数チェックだけで即session.translate()へ
+
+### 3. Whitespace & Separator Preservation
+- **Q:** 改行や段落区切りの保持方法
+- **A:** セパレーター記録方式を選択（ブロック→文の2段階分割より推奨）
+- NLTokenizerのRange<String.Index>間のギャップ文字列を記録して結合時に復元
+
+### 4. TextChunkerのコード配置
+- **Q:** 新ファイルかTextNormalizationに追加か
+- **A:** 新ファイル Transy/Translation/TextChunker.swift — 単一責任、テストしやすい
+
+### 5. シマーとの統合
+- **Q:** チャンク翻訳中のシマー表示方法
+- **Discussion:** translate(batch:)のストリーミングプログレスも検討したが、translations(from:)の一括方式を選択
+- **A:** シマーは現行のまま（全体にかかる）+ translations(from:)で一括翻訳
+- **Deferred:** プログレス表示は将来のマイルストーンで検討

--- a/.planning/phases/15-chunked-translation/15-VERIFICATION.md
+++ b/.planning/phases/15-chunked-translation/15-VERIFICATION.md
@@ -1,0 +1,114 @@
+---
+phase: 15-chunked-translation
+verified: 2026-04-12T14:10:27Z
+status: passed
+score: 7/7 must-haves verified
+re_verification: false
+---
+
+# Phase 15: Chunked Translation Verification Report
+
+**Phase Goal:** Texts longer than 200 characters are split at sentence boundaries and translated as a single batch, returning a correctly ordered result
+**Verified:** 2026-04-12T14:10:27Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Text of 200 characters or fewer returns a single ChunkedSegment without invoking NLTokenizer | ✓ VERIFIED | `guard text.count > threshold` at line 13 of TextChunker.swift returns `[ChunkedSegment(chunk: text, separator: "")]`; tests `shortTextBypass`, `exactlyAtThreshold`, `sentencesGroupedWithinThreshold` confirm |
+| 2 | Text over 200 characters is split at NLTokenizer sentence boundaries into multiple ChunkedSegment values | ✓ VERIFIED | `NLTokenizer(unit: .sentence)` at line 17, `enumerateTokens` at line 21; test `splitsAtSentenceBoundaries` confirms `result.count > 1` |
+| 3 | Sentences are grouped greedily so each chunk stays within the threshold | ✓ VERIFIED | Greedy loop lines 34-44, uses `text.distance(from:to:)` at line 36 for character counting; test `sentencesGroupedWithinThreshold` confirms short sentences stay grouped |
+| 4 | Multiple chunks are submitted as a single batch call via session.translations(from:) | ✓ VERIFIED | PopupView.swift line 157: `session.translations(from: requests)` in else-branch when `segments.count > 1` |
+| 5 | Translated chunks are recombined with original separators in input order | ✓ VERIFIED | PopupView.swift lines 158-161: `zip(responses, segments).map { response, segment in response.targetText + segment.separator }.joined()`; test `roundtripInvariant` and `paragraphBreaksPreserved` confirm separator fidelity |
+| 6 | Single-chunk text (≤200 chars) uses session.translate() directly — zero batch overhead | ✓ VERIFIED | PopupView.swift line 148: `if segments.count <= 1` → `session.translate()` at line 149; `translate(batch:)` absent (grep confirms exit code 1) |
+| 7 | TextChunker.chunk() runs on MainActor in body before translationAction closure (Pitfall 5) | ✓ VERIFIED | PopupView.swift line 117: `let segments = TextChunker.chunk(text: requestContext.sourceText)` in `body` (MainActor); `translationAction` is `nonisolated` at line 138 and receives segments as parameter — NLTokenizer never enters nonisolated context |
+
+**Score:** 7/7 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `Transy/Translation/TextChunker.swift` | enum TextChunker with ChunkedSegment struct and chunk() static method | ✓ VERIFIED | 72 lines. Contains `enum TextChunker`, `struct ChunkedSegment: Sendable, Equatable`, `static func chunk(text:threshold:)`, `import NaturalLanguage`, `NLTokenizer(unit: .sentence)`, `enumerateTokens`, `trimmingCharacters` filter, `text.count > threshold` guard, fallback for empty segments |
+| `TransyTests/TextChunkerTests.swift` | Unit tests for TextChunker behavior | ✓ VERIFIED | 83 lines. 9 `@Test` functions: shortTextBypass, exactlyAtThreshold, splitsAtSentenceBoundaries, roundtripInvariant, paragraphBreaksPreserved, noWhitespaceOnlyChunks, defaultThreshold, singleSentenceOverThreshold, sentencesGroupedWithinThreshold |
+| `Transy/Popup/PopupView.swift` | Modified LoadingPopupText with chunked batch translation path | ✓ VERIFIED | Contains `TextChunker.chunk(text:)` call in body, `segments` parameter in translationAction, `session.translations(from: requests)` batch call, `zip(responses, segments)` recombination, `segments.count <= 1` single-chunk bypass |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `TextChunker.swift` | `NLTokenizer(unit: .sentence)` | Sentence tokenization for text > threshold | ✓ WIRED | Line 17: `NLTokenizer(unit: .sentence)` with `enumerateTokens` at line 21 |
+| `LoadingPopupText.body` | `TextChunker.chunk(text:)` | Synchronous call on MainActor before closure | ✓ WIRED | Line 117: `let segments = TextChunker.chunk(text: requestContext.sourceText)` in body |
+| `translationAction closure` | `session.translations(from: requests)` | Batch API for multi-chunk translation | ✓ WIRED | Line 157: `let responses = try await session.translations(from: requests)` |
+| `translationAction closure` | `onResult` | zip(responses, segments) joined with separators | ✓ WIRED | Lines 158-161: `zip(responses, segments).map { ... }.joined()` → line 165: `await onResult(...)` |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|--------------------|--------|
+| `PopupView.swift` (LoadingPopupText) | `segments` | `TextChunker.chunk(text: requestContext.sourceText)` | Yes — NLTokenizer sentence splitting on real input text | ✓ FLOWING |
+| `PopupView.swift` (translationAction) | `translatedText` | `session.translate()` or `session.translations(from:)` | Yes — Apple Translation framework real API calls | ✓ FLOWING |
+| `PopupView.swift` (translationAction) | `translatedText` recombination | `zip(responses, segments).map { ... }.joined()` | Yes — translated chunks joined with original separators | ✓ FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| TextChunker exists as enum namespace | `grep -q "enum TextChunker" Transy/Translation/TextChunker.swift` | Found | ✓ PASS |
+| 9 test functions exist | `grep -c "@Test" TransyTests/TextChunkerTests.swift` → 9 | 9 | ✓ PASS |
+| Batch API wired (not translate(batch:)) | `grep "translate(batch:" PopupView.swift` → exit 1 (absent) | Absent | ✓ PASS |
+| Files in Xcode project | `grep "TextChunker" Transy.xcodeproj/project.pbxproj` | Found | ✓ PASS |
+| Commits exist | `git log --oneline` shows 5 phase-15 commits | 4fbb431, ff7f23f, a339bf8 + docs | ✓ PASS |
+
+Note: Build and test execution deferred to human verification — requires macOS Xcode toolchain.
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| CHK-01 | 15-01 | Text longer than 200 characters is split at sentence boundaries (NLTokenizer) before translation | ✓ SATISFIED | TextChunker.swift: `NLTokenizer(unit: .sentence)`, `text.count > threshold` guard, `enumerateTokens` sentence splitting; 9 tests verify behavior |
+| CHK-02 | 15-02 | Batch `translations(from:)` API is used; results are joined in input order | ✓ SATISFIED | PopupView.swift: `session.translations(from: requests)` at line 157; `zip(responses, segments).map { ... }.joined()` preserves input order |
+| CHK-03 | 15-01, 15-02 | Text of 200 characters or fewer bypasses chunking and is translated directly | ✓ SATISFIED | TextChunker.swift: `guard text.count > threshold` returns single segment; PopupView.swift: `segments.count <= 1` → `session.translate()` directly |
+
+**Orphaned requirements:** None. REQUIREMENTS.md maps CHK-01, CHK-02, CHK-03 to Phase 15; all three are covered by plans 15-01 and 15-02.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| — | — | No anti-patterns found | — | — |
+
+No TODOs, FIXMEs, placeholders, stub returns, or hardcoded empty data detected in any phase files.
+
+### Human Verification Required
+
+### 1. Build and Test Suite Pass
+
+**Test:** Run `make generate && xcodebuild test -scheme Transy -destination 'platform=macOS' -derivedDataPath .build -only-testing:TransyTests -quiet`
+**Expected:** Exit code 0, all 9 TextChunkerTests pass, full TransyTests suite passes with no regressions
+**Why human:** Requires macOS with Xcode installed; cannot execute xcodebuild in verification environment
+
+### 2. End-to-End Long Text Translation
+
+**Test:** Select a text >200 characters in any application, trigger Transy translation
+**Expected:** Translation succeeds; result reads as continuous prose; shimmer plays during loading; no visible chunk seams in output
+**Why human:** Requires running app with Apple Translation framework, real language model, and UI observation
+
+### 3. Short Text Translation (No Regression)
+
+**Test:** Select a short text ≤200 characters, trigger Transy translation
+**Expected:** Translation succeeds immediately via single-call path; no delay increase from chunking logic
+**Why human:** Requires running app and subjective latency assessment
+
+### Gaps Summary
+
+No gaps found. All 7 observable truths verified. All 3 required artifacts pass all 4 verification levels (exists, substantive, wired, data flowing). All 4 key links verified as wired. All 3 requirements (CHK-01, CHK-02, CHK-03) satisfied with implementation evidence. No anti-patterns detected. 5 commits trace the complete TDD cycle (RED → GREEN → integration).
+
+---
+
+_Verified: 2026-04-12T14:10:27Z_
+_Verifier: the agent (gsd-verifier)_

--- a/Transy.xcodeproj/project.pbxproj
+++ b/Transy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17CC30F95F588EC099697A79 /* TextChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1C1E09F0DD897D87626E82 /* TextChunkerTests.swift */; };
 		204F94D0D810F1E162F9E613 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D1B48CD36755DAA5C8B67 /* MenuBarView.swift */; };
 		23528C1A8D6C4E3E817D396B /* PopupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A903E7EC95F736D96FDA48 /* PopupController.swift */; };
 		2A462835DB11A8E7C0466126 /* PopupPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88A7A5D6B25972BC5CE7475 /* PopupPositioningTests.swift */; };
@@ -29,6 +30,7 @@
 		AAFA7FD602DEF26AC12C9B9F /* TranslationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1D7383317B9A12BC538EC8 /* TranslationCoordinator.swift */; };
 		AC26B804437DB031761E20D3 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DC9F4A18702B8B9A29CFC9 /* SettingsStore.swift */; };
 		B1EB76E4610AD4BDF6EBC9B7 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A40B5997CA8261D6C13685A /* GeneralSettingsView.swift */; };
+		C1C51BBAB99C14AE37A12FF0 /* TextChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4D0A7F1BD190240D633616 /* TextChunker.swift */; };
 		C9B1B3F6BC1033CEFD7EA044 /* TranslationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615771C52D62AEAC2E7F273C /* TranslationCoordinatorTests.swift */; };
 		CBB7A7141F49E1A7095D6372 /* SupportedLanguageOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FE6B67971BD2B40E2F946A /* SupportedLanguageOption.swift */; };
 		D7873F0DC83895715B11BAC9 /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571781F5ACF1EB7FBE63EBC /* ShimmerModifier.swift */; };
@@ -61,6 +63,7 @@
 		0A40B5997CA8261D6C13685A /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		1571781F5ACF1EB7FBE63EBC /* ShimmerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifier.swift; sourceTree = "<group>"; };
 		1A3FE03FD3BB8F70C1424BCA /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
+		1B4D0A7F1BD190240D633616 /* TextChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextChunker.swift; sourceTree = "<group>"; };
 		21E661331FEAC8733B0C9F23 /* TranslationTaskConfigurationReloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationTaskConfigurationReloaderTests.swift; sourceTree = "<group>"; };
 		2524A77BC83DDE3C480C0F14 /* TextNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextNormalization.swift; sourceTree = "<group>"; };
 		37F1F84333208183CD5E0742 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
@@ -69,6 +72,7 @@
 		45A08DBC760C4F5F1CC6378D /* TransyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransyTests.swift; sourceTree = "<group>"; };
 		47FE6B67971BD2B40E2F946A /* SupportedLanguageOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedLanguageOption.swift; sourceTree = "<group>"; };
 		4A6419329179F1E05CAA17FA /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
+		4B1C1E09F0DD897D87626E82 /* TextChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextChunkerTests.swift; sourceTree = "<group>"; };
 		4E11588B37785CBBB800DC5E /* PopupTextLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTextLayoutTests.swift; sourceTree = "<group>"; };
 		5FC8394AFE49268B2F159F4F /* ShimmerModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifierTests.swift; sourceTree = "<group>"; };
 		615771C52D62AEAC2E7F273C /* TranslationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -181,6 +185,7 @@
 				1A3FE03FD3BB8F70C1424BCA /* SettingsStoreTests.swift */,
 				5FC8394AFE49268B2F159F4F /* ShimmerModifierTests.swift */,
 				F60EB17A8A5F1F992BC90047 /* TargetLanguageSnapshotTests.swift */,
+				4B1C1E09F0DD897D87626E82 /* TextChunkerTests.swift */,
 				615771C52D62AEAC2E7F273C /* TranslationCoordinatorTests.swift */,
 				C4FC79CA1B09F4378844F508 /* TranslationRaceGuardTests.swift */,
 				21E661331FEAC8733B0C9F23 /* TranslationTaskConfigurationReloaderTests.swift */,
@@ -222,6 +227,7 @@
 		E812C7FFD5FF99F2A6A62DC1 /* Translation */ = {
 			isa = PBXGroup;
 			children = (
+				1B4D0A7F1BD190240D633616 /* TextChunker.swift */,
 				2524A77BC83DDE3C480C0F14 /* TextNormalization.swift */,
 				3B1D7383317B9A12BC538EC8 /* TranslationCoordinator.swift */,
 				8007AE0E9F8439938296AE4E /* TranslationErrorMapper.swift */,
@@ -378,6 +384,7 @@
 				7EB2D150C6557F03D03EE672 /* SettingsStoreTests.swift in Sources */,
 				FA11E29553C4FB989AB0CB4B /* ShimmerModifierTests.swift in Sources */,
 				9B88142989507F94F5A02C89 /* TargetLanguageSnapshotTests.swift in Sources */,
+				17CC30F95F588EC099697A79 /* TextChunkerTests.swift in Sources */,
 				C9B1B3F6BC1033CEFD7EA044 /* TranslationCoordinatorTests.swift in Sources */,
 				8C0375FD479C9642EC9F0A92 /* TranslationRaceGuardTests.swift in Sources */,
 				A2FB8599B6B1B4F5BC41D43B /* TranslationTaskConfigurationReloaderTests.swift in Sources */,
@@ -403,6 +410,7 @@
 				83ADDBAA20196C7AED7EDDF4 /* SettingsView.swift in Sources */,
 				D7873F0DC83895715B11BAC9 /* ShimmerModifier.swift in Sources */,
 				CBB7A7141F49E1A7095D6372 /* SupportedLanguageOption.swift in Sources */,
+				C1C51BBAB99C14AE37A12FF0 /* TextChunker.swift in Sources */,
 				DB8EBF7032C96F568FF72EC1 /* TextNormalization.swift in Sources */,
 				AAFA7FD602DEF26AC12C9B9F /* TranslationCoordinator.swift in Sources */,
 				F3DEA91AAA877AC3FE7F4E2F /* TranslationErrorMapper.swift in Sources */,

--- a/Transy/Popup/PopupView.swift
+++ b/Transy/Popup/PopupView.swift
@@ -114,6 +114,7 @@ private struct LoadingPopupText: View {
         let targetLanguage = targetLanguage
         let onResult = onResult
         let onError = onError
+        let segments = TextChunker.chunk(text: requestContext.sourceText)
 
         return PopupText(text: requestContext.sourceText, isMuted: true)
             .shimmer()
@@ -127,6 +128,7 @@ private struct LoadingPopupText: View {
                 translationConfiguration,
                 action: Self.translationAction(
                     requestContext: requestContext,
+                    segments: segments,
                     onResult: onResult,
                     onError: onError
                 )
@@ -135,16 +137,35 @@ private struct LoadingPopupText: View {
 
     nonisolated private static func translationAction(
         requestContext: LoadingRequestContext,
+        segments: [TextChunker.ChunkedSegment],
         onResult: @escaping @Sendable (UUID, String, String) async -> Void,
         onError: @escaping @Sendable (UUID, String, String) async -> Void
     ) -> (TranslationSession) async -> Void {
         { session in
             do {
-                let response = try await session.translate(requestContext.sourceText)
+                let translatedText: String
+
+                if segments.count <= 1 {
+                    let response = try await session.translate(
+                        segments.first?.chunk ?? requestContext.sourceText
+                    )
+                    translatedText = response.targetText
+                } else {
+                    let requests = segments.map { segment in
+                        TranslationSession.Request(sourceText: segment.chunk)
+                    }
+                    let responses = try await session.translations(from: requests)
+                    translatedText = zip(responses, segments)
+                        .map { response, segment in
+                            response.targetText + segment.separator
+                        }
+                        .joined()
+                }
+
                 await onResult(
                     requestContext.requestID,
                     requestContext.sourceText,
-                    response.targetText
+                    translatedText
                 )
             } catch is CancellationError {
                 return

--- a/Transy/Translation/TextChunker.swift
+++ b/Transy/Translation/TextChunker.swift
@@ -17,10 +17,16 @@ enum TextChunker {
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
 
-        var sentenceRanges: [Range<String.Index>] = []
+        var allRanges: [Range<String.Index>] = []
         tokenizer.enumerateTokens(in: text.startIndex ..< text.endIndex) { range, _ in
-            sentenceRanges.append(range)
+            allRanges.append(range)
             return true
+        }
+
+        // Filter whitespace-only "sentences" (NLTokenizer treats blank lines as sentences).
+        // Keeping only real sentences ensures blank lines fall into inter-range gaps (separators).
+        let sentenceRanges = allRanges.filter { range in
+            !text[range].allSatisfy(\.isWhitespace)
         }
 
         guard !sentenceRanges.isEmpty else {
@@ -46,11 +52,7 @@ enum TextChunker {
 
         var segments: [ChunkedSegment] = []
         for (index, group) in groups.enumerated() {
-            let chunkText = String(text[group.first.lowerBound ..< group.last.upperBound])
-
-            if chunkText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                continue
-            }
+            var chunkText = String(text[group.first.lowerBound ..< group.last.upperBound])
 
             let separatorEnd: String.Index
             if index + 1 < groups.count {
@@ -58,9 +60,31 @@ enum TextChunker {
             } else {
                 separatorEnd = text.endIndex
             }
-            let separator = String(text[group.last.upperBound ..< separatorEnd])
+            var separator = String(text[group.last.upperBound ..< separatorEnd])
+
+            // Move trailing whitespace from chunk to separator so translation
+            // cannot strip newlines that separate paragraphs.
+            let trimmedChunk = chunkText.replacingOccurrences(
+                of: "\\s+$", with: "", options: .regularExpression
+            )
+            if trimmedChunk.count < chunkText.count {
+                let trailingWS = String(chunkText[chunkText.index(chunkText.startIndex, offsetBy: trimmedChunk.count)...])
+                separator = trailingWS + separator
+                chunkText = trimmedChunk
+            }
 
             segments.append(ChunkedSegment(chunk: chunkText, separator: separator))
+        }
+
+        // Handle leading whitespace before first sentence
+        if let firstRange = sentenceRanges.first,
+           firstRange.lowerBound > text.startIndex,
+           !segments.isEmpty {
+            let leading = String(text[text.startIndex ..< firstRange.lowerBound])
+            segments[0] = ChunkedSegment(
+                chunk: leading + segments[0].chunk,
+                separator: segments[0].separator
+            )
         }
 
         if segments.isEmpty {

--- a/Transy/Translation/TextChunker.swift
+++ b/Transy/Translation/TextChunker.swift
@@ -1,0 +1,15 @@
+import NaturalLanguage
+
+enum TextChunker {
+    struct ChunkedSegment: Sendable, Equatable {
+        let chunk: String
+        let separator: String
+    }
+
+    static func chunk(
+        text: String,
+        threshold: Int = 200
+    ) -> [ChunkedSegment] {
+        []
+    }
+}

--- a/Transy/Translation/TextChunker.swift
+++ b/Transy/Translation/TextChunker.swift
@@ -6,7 +6,7 @@ enum TextChunker {
         let separator: String
     }
 
-    static func chunk(
+    @MainActor static func chunk(
         text: String,
         threshold: Int = 200
     ) -> [ChunkedSegment] {
@@ -84,10 +84,6 @@ enum TextChunker {
                 chunk: leading + segments[0].chunk,
                 separator: segments[0].separator
             )
-        }
-
-        if segments.isEmpty {
-            return [ChunkedSegment(chunk: text, separator: "")]
         }
 
         return segments

--- a/Transy/Translation/TextChunker.swift
+++ b/Transy/Translation/TextChunker.swift
@@ -10,6 +10,63 @@ enum TextChunker {
         text: String,
         threshold: Int = 200
     ) -> [ChunkedSegment] {
-        []
+        guard text.count > threshold else {
+            return [ChunkedSegment(chunk: text, separator: "")]
+        }
+
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        var sentenceRanges: [Range<String.Index>] = []
+        tokenizer.enumerateTokens(in: text.startIndex ..< text.endIndex) { range, _ in
+            sentenceRanges.append(range)
+            return true
+        }
+
+        guard !sentenceRanges.isEmpty else {
+            return [ChunkedSegment(chunk: text, separator: "")]
+        }
+
+        var groups: [(first: Range<String.Index>, last: Range<String.Index>)] = []
+        var groupFirst = sentenceRanges[0]
+        var groupLast = sentenceRanges[0]
+
+        for i in 1 ..< sentenceRanges.count {
+            let candidate = sentenceRanges[i]
+            let spanLength = text.distance(from: groupFirst.lowerBound, to: candidate.upperBound)
+            if spanLength <= threshold {
+                groupLast = candidate
+            } else {
+                groups.append((first: groupFirst, last: groupLast))
+                groupFirst = candidate
+                groupLast = candidate
+            }
+        }
+        groups.append((first: groupFirst, last: groupLast))
+
+        var segments: [ChunkedSegment] = []
+        for (index, group) in groups.enumerated() {
+            let chunkText = String(text[group.first.lowerBound ..< group.last.upperBound])
+
+            if chunkText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                continue
+            }
+
+            let separatorEnd: String.Index
+            if index + 1 < groups.count {
+                separatorEnd = groups[index + 1].first.lowerBound
+            } else {
+                separatorEnd = text.endIndex
+            }
+            let separator = String(text[group.last.upperBound ..< separatorEnd])
+
+            segments.append(ChunkedSegment(chunk: chunkText, separator: separator))
+        }
+
+        if segments.isEmpty {
+            return [ChunkedSegment(chunk: text, separator: "")]
+        }
+
+        return segments
     }
 }

--- a/Transy/Translation/TextChunker.swift
+++ b/Transy/Translation/TextChunker.swift
@@ -1,7 +1,7 @@
 import NaturalLanguage
 
 enum TextChunker {
-    struct ChunkedSegment: Sendable, Equatable {
+    struct ChunkedSegment: Equatable {
         let chunk: String
         let separator: String
     }
@@ -54,11 +54,10 @@ enum TextChunker {
         for (index, group) in groups.enumerated() {
             var chunkText = String(text[group.first.lowerBound ..< group.last.upperBound])
 
-            let separatorEnd: String.Index
-            if index + 1 < groups.count {
-                separatorEnd = groups[index + 1].first.lowerBound
+            let separatorEnd = if index + 1 < groups.count {
+                groups[index + 1].first.lowerBound
             } else {
-                separatorEnd = text.endIndex
+                text.endIndex
             }
             var separator = String(text[group.last.upperBound ..< separatorEnd])
 

--- a/TransyTests/TextChunkerTests.swift
+++ b/TransyTests/TextChunkerTests.swift
@@ -7,7 +7,7 @@ struct TextChunkerTests {
         let result = TextChunker.chunk(text: "Hello world.", threshold: 200)
         #expect(result.count == 1)
         #expect(result.first?.chunk == "Hello world.")
-        #expect(result.first?.separator == "")
+        #expect(result.first?.separator.isEmpty == true)
     }
 
     @Test("text exactly at threshold returns single segment")
@@ -16,7 +16,7 @@ struct TextChunkerTests {
         let result = TextChunker.chunk(text: text, threshold: 200)
         #expect(result.count == 1)
         #expect(result.first?.chunk == text)
-        #expect(result.first?.separator == "")
+        #expect(result.first?.separator.isEmpty == true)
     }
 
     @Test("splits at sentence boundaries when text exceeds threshold")

--- a/TransyTests/TextChunkerTests.swift
+++ b/TransyTests/TextChunkerTests.swift
@@ -1,0 +1,83 @@
+import Testing
+@testable import Transy
+
+struct TextChunkerTests {
+    @Test("short text bypass returns single segment without splitting")
+    func shortTextBypass() {
+        let result = TextChunker.chunk(text: "Hello world.", threshold: 200)
+        #expect(result.count == 1)
+        #expect(result.first?.chunk == "Hello world.")
+        #expect(result.first?.separator == "")
+    }
+
+    @Test("text exactly at threshold returns single segment")
+    func exactlyAtThreshold() {
+        let text = String(repeating: "a", count: 200)
+        let result = TextChunker.chunk(text: text, threshold: 200)
+        #expect(result.count == 1)
+        #expect(result.first?.chunk == text)
+        #expect(result.first?.separator == "")
+    }
+
+    @Test("splits at sentence boundaries when text exceeds threshold")
+    func splitsAtSentenceBoundaries() {
+        let text = "The quick brown fox jumped. The lazy dog slept. The cat watched."
+        let result = TextChunker.chunk(text: text, threshold: 30)
+        #expect(result.count > 1)
+        for segment in result {
+            let trimmed = segment.chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(!trimmed.isEmpty)
+        }
+    }
+
+    @Test("roundtrip invariant: chunks + separators reconstruct original text")
+    func roundtripInvariant() {
+        let text = "First sentence here. Second sentence follows.\nThird on new line. Fourth is last."
+        let result = TextChunker.chunk(text: text, threshold: 30)
+        let reconstructed = result.map { $0.chunk + $0.separator }.joined()
+        #expect(reconstructed == text)
+    }
+
+    @Test("paragraph breaks are preserved in roundtrip")
+    func paragraphBreaksPreserved() {
+        let text = "First paragraph.\n\nSecond paragraph."
+        let result = TextChunker.chunk(text: text, threshold: 20)
+        let reconstructed = result.map { $0.chunk + $0.separator }.joined()
+        #expect(reconstructed == text)
+        #expect(reconstructed.contains("\n\n"))
+    }
+
+    @Test("no whitespace-only chunks in output")
+    func noWhitespaceOnlyChunks() {
+        let text = "Line one.\n\n\nLine two."
+        let result = TextChunker.chunk(text: text, threshold: 15)
+        for segment in result {
+            let trimmed = segment.chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(!trimmed.isEmpty)
+        }
+    }
+
+    @Test("default threshold is 200")
+    func defaultThreshold() {
+        let shortText = "Short text."
+        let result = TextChunker.chunk(text: shortText)
+        #expect(result.count == 1)
+        #expect(result.first?.chunk == shortText)
+    }
+
+    @Test("single sentence over threshold returns exactly one segment")
+    func singleSentenceOverThreshold() {
+        let text = String(repeating: "word ", count: 50) + "end."
+        let result = TextChunker.chunk(text: text)
+        #expect(result.count == 1)
+        #expect(result.first?.chunk == text)
+    }
+
+    @Test("sentences grouped within threshold returns single segment")
+    func sentencesGroupedWithinThreshold() {
+        let text = "Short. Also short. Tiny."
+        let result = TextChunker.chunk(text: text, threshold: 200)
+        #expect(result.count == 1)
+        #expect(result.first?.chunk == text)
+    }
+}

--- a/TransyTests/TextChunkerTests.swift
+++ b/TransyTests/TextChunkerTests.swift
@@ -1,6 +1,7 @@
 import Testing
 @testable import Transy
 
+@MainActor
 struct TextChunkerTests {
     @Test("short text bypass returns single segment without splitting")
     func shortTextBypass() {
@@ -99,6 +100,7 @@ struct TextChunkerTests {
         // No chunk should start or end with blank lines
         for segment in result {
             #expect(!segment.chunk.hasPrefix("\n\n"))
+            #expect(!segment.chunk.hasSuffix("\n\n"))
         }
     }
 }

--- a/TransyTests/TextChunkerTests.swift
+++ b/TransyTests/TextChunkerTests.swift
@@ -80,4 +80,25 @@ struct TextChunkerTests {
         #expect(result.count == 1)
         #expect(result.first?.chunk == text)
     }
+
+    @Test("blank lines between paragraphs preserved as separators in long text")
+    func blankLinesPreservedInLongText() {
+        let text = """
+        First paragraph sentence one. First paragraph sentence two. First paragraph keeps going here.
+
+        Second paragraph starts here. It also has multiple sentences. And it continues further onward.
+
+        Third paragraph with additional content. More sentences follow here for testing purposes.
+        """
+        let result = TextChunker.chunk(text: text, threshold: 100)
+        let reconstructed = result.map { $0.chunk + $0.separator }.joined()
+        #expect(reconstructed == text)
+        // Blank lines must be in separators, not in chunks
+        let hasSeparatorWithBlankLine = result.contains { $0.separator.contains("\n\n") }
+        #expect(hasSeparatorWithBlankLine, "At least one separator should contain a blank line")
+        // No chunk should start or end with blank lines
+        for segment in result {
+            #expect(!segment.chunk.hasPrefix("\n\n"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

**Phase 15: Chunked Translation**
**Goal:** Texts longer than 200 characters are split at sentence boundaries and translated as a single batch.
**Status:** Verified ✓ (7/7 must-haves)

TextChunker splits long text at sentence boundaries via NLTokenizer, groups sentences greedily into ≤200 char chunks, and records inter-chunk whitespace as separators. PopupView's translation action uses the batch `translations(from:)` API for multi-chunk text and direct `session.translate()` for short text. Blank lines between paragraphs are preserved by filtering whitespace-only NLTokenizer ranges and trimming trailing whitespace from chunks into separators.

## Changes

### Plan 15-01: TextChunker TDD
NLTokenizer sentence-boundary splitter with greedy grouping, separator recording, and 10-test TDD suite.

**Key files:**
- `Transy/Translation/TextChunker.swift` — enum namespace with `chunk(text:threshold:)` static method
- `TransyTests/TextChunkerTests.swift` — 10 tests (short bypass, splitting, roundtrip, blank lines, empty chunks)

### Plan 15-02: Wire Batch Translation
Batch `translations(from:)` API wired into PopupView with MainActor-safe chunking and separator-preserving recombination.

**Key files:**
- `Transy/Popup/PopupView.swift` — Modified `LoadingPopupText.body` and `translationAction`

### Bug Fix: Blank Line Preservation
NLTokenizer treats `\n` as separate "sentences" with zero-width gaps. Fixed by filtering whitespace-only ranges before grouping and trimming trailing whitespace from chunks into separators.

## Requirements Addressed

| ID | Requirement | Status |
|----|-------------|--------|
| CHK-01 | Split at sentence boundaries via NLTokenizer | ✅ |
| CHK-02 | Batch translations(from:) API, results joined in input order | ✅ |
| CHK-03 | ≤200 chars bypasses chunking (short-text bypass) | ✅ |

## Verification

- [x] Automated verification: 7/7 must-haves passed
- [x] Manual: Build and run tests locally
- [x] Manual: Translate long text (>200 chars) end-to-end
- [x] Manual: Verify short text still works (regression check)

## Key Decisions

- NLTokenizer `.sentence` for sentence detection (not regex)
- Greedy sentence grouping: pack as many sentences as fit within threshold
- Separator = gap between filtered NLTokenizer ranges + trimmed trailing whitespace
- `TextChunker.chunk()` on MainActor before nonisolated closure (Pitfall 5)
- Batch API `translations(from:)` not `translate(batch:)` (Pitfall 4)

Closes #29
Relates to #27
